### PR TITLE
Args to lisp

### DIFF
--- a/femto.rc.in
+++ b/femto.rc.in
@@ -32,6 +32,17 @@
 (defun edit-config()
   (find-file (confn config_file)))
 
+(defun getopts (opts pos)
+  (setq o (car opts))
+  (cond
+    ((null o))
+    ((eq (string.ref o 0) "+")
+     (getopts (cdr opts) (string->number (string.substring o 1 (- (string.length o) 1)))))
+    (t
+     (find-file o)
+     (goto-line pos)
+     (getopts (cdr opts) 0))))
+
 ;;
 ;;  Load extensions
 ;;
@@ -64,3 +75,4 @@
 
 (load (confn config_file))
 
+(getopts argv 0)

--- a/main.c
+++ b/main.c
@@ -8,7 +8,7 @@
 int main(int argc, char **argv)
 {
 	setup_keys();
-	(void)init_lisp();
+	(void)init_lisp(argc, argv);
 
 
 	setlocale(LC_ALL, "") ; /* required for 3,4 byte UTF8 chars */
@@ -28,19 +28,8 @@ int main(int argc, char **argv)
 	init_pair(ID_DOUBLE_STRING, COLOR_YELLOW, COLOR_BLACK);  /* double quoted strings */
 	init_pair(ID_BRACE, COLOR_BLACK, COLOR_CYAN);            /* brace highlight */
 	
-	if (1 < argc) {
-		char bname[NBUFN];
-		char fname[NAME_MAX + 1];
-		/* Save filename irregardless of load() success. */
-		safe_strncpy(fname, argv[1], NAME_MAX);
-		make_buffer_name(bname, fname);
-		curbp = find_buffer(bname, TRUE);
-		(void)insert_file(fname, FALSE);
-		strcpy(curbp->b_fname, fname);
-	} else {
-		curbp = find_buffer(str_scratch, TRUE);
-		strncpy(curbp->b_bname, str_scratch, STRBUF_S);
-	}
+	curbp = find_buffer(str_scratch, TRUE);
+	strncpy(curbp->b_bname, str_scratch, STRBUF_S);
 
 	wheadp = curwp = new_window();
 	one_window(curwp);


### PR DESCRIPTION
All files on the command line are read in, optionally jump to a specific line
    
- `main.c` does no command line processing anymore.
- `argc` and `argv` are passed to `init_lisp`.
- Lisp adds two global variables:
  - `argv0` is the path with which Femto was called.
  - `argv` is a list of the command line arguments to Femto.
  - `femto.rc` defun's `getopts`, which processes `argv`:
  - If an option starts with + the rest is converted to a number. The cursor
    in the next file to be opened is set to this line number.
- `getopts` is run on `argv` after loading the user config. This allows to
    redefine `getopts` before processing `argv`.

Note: Sorry, docs are not updated yet.