### PR TITLE
Fix: add missing quotes for script dir

### DIFF
--- a/femto.rc.in
+++ b/femto.rc.in
@@ -36,6 +36,7 @@
   (setq o (car opts))
   (cond
     ((null o))
+    ((eq o "+"))
     ((eq (string.ref o 0) "+")
      (getopts (cdr opts) (string->number (string.substring o 1 (- (string.length o) 1)))))
     (t


### PR DESCRIPTION
When `getopts` finds an option starting with "+" it takes the rest of the option and converts it to a number.  The algorithm to find the index of the last character is to subtract 1 from the string length, which gives 0 on a lone "+". (string.substring s 1 0) then throws an exception.

When `getopts` is run from the `femto.rc` file throwing this exception results in a segfault, which is the true bug.

The current commit just handles the special case of a lone "+" option in `getopts`.