### PR TITLE
Fix blocking shell-command. Make C code less, Lisp code more, Add key…

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Generally, the procedure for copying or moving text is:
 3. Move the cursor to the desired location and yank it back (with ^Y).
 
 ### Searching
+
     C-S or C-R enters the search prompt, where you type the search string
     BACKSPACE - will reduce the search string, any other character will extend it
     C-S at the search prompt will search forward, will wrap at end of the buffer
@@ -160,7 +161,7 @@ Generally, the procedure for copying or moving text is:
 There are two ways to interract with Tiny-Lisp within Femto.
 
 * You can use C-] to find the last s-expression above the cursor and send it to be evaluated.
-* You can mark a region and send the whole region to be evaluated.
+* You can mark a region and send the whole region to be evaluated with ESC-].
 
 ### Lisp Interaction - finding and evaluating the last s-expression
 
@@ -281,6 +282,7 @@ Additional extensions loaded by `femto.rc`
 (list-buffers)                          ;; list all the buffers in a buffer called *buffers*
 (find-file "file.txt")                  ;; loads file into a new buffer
 (save-buffer)                           ;; saves the current buffer to disk
+(erase-buffer)                          ;; erases all text of the current buffer
 
 ;;
 ;; window handling
@@ -344,6 +346,7 @@ Additional extensions loaded by `femto.rc`
 (clear-message-line)                    ;; clear the message line
 (prompt "prompt" "initial response")    ;; prompts for a value on the command line and returns the response
 (show-prompt p r)                       ;; display the prompt and response but do not go into editing mode of the response
+(prompt-filename "prompt")              ;; display the prompt with file search
 (update-display)                        ;; calls the display function so that the screen is updated
 (refresh)                               ;; marks all windows for updates and the calls update-display
 

--- a/command.c
+++ b/command.c
@@ -287,12 +287,6 @@ int goto_line(int line)
 	}
 }
 
-void insertfile()
-{
-	if (getfilename(str_insert_file, (char*) response_buf, NAME_MAX))
-		(void)insert_file(response_buf, TRUE);
-}
-
 void i_readfile()
 {
 	if (FALSE == getfilename(str_read, (char*)response_buf, NAME_MAX))
@@ -680,34 +674,6 @@ void match_paren_backwards(buffer_t *bp, char open_paren, char close_paren)
 		position--;
 	}
 	bp->b_paren = NOPAREN;
-}
-
-void i_shell_command()
-{
-	if (getinput(str_shell_cmd, (char*)response_buf, NAME_MAX, F_CLEAR))
-		shell_command(response_buf);
-}
-
-void shell_command(char *command)
-{
-	char sys_command[255];
-	buffer_t *bp;
-	char *output_file = get_temp_file();
-
-	sprintf(sys_command, "%s > %s 2>&1", command, output_file);
-	//debug("sys_command: '%s'\n", sys_command);
-
-	if (0 != system(sys_command))
-		return;
-
-	bp = find_buffer(str_output, TRUE);
-	disassociate_b(curwp); /* we are leaving the old buffer for a new one */
-	curbp = bp;
-	associate_b2w(curbp, curwp);
-
-	e_load_file(output_file);
-	msg(""); /* clear the msg line, dont display temp filename */
-	safe_strncpy(curbp->b_bname, str_output, NBUFN);
 }
 
 int add_mode_global(char *mode_name)

--- a/femto.rc.in
+++ b/femto.rc.in
@@ -17,11 +17,20 @@
 (setq config_file "femto.rc")
 
 ;; concatenate a list of strings
-(defmacro concat args
+
+(defun stringify (s)
+  (cond
+    ((null s)    "")
+    ((number? s) (number->string s))
+    ((string? s) s) 
+    ((consp s)   (string.append (stringify (car s)) (stringify (cdr s))))
+    (t (string.append "" s))))
+
+(defun concat args
   (cond
     ((null args) "")
-    ((null (cdr args)) (car args))
-    (t (list (quote string.append) (car args) (cons (quote concat) (cdr args)))) ))
+    ((null (cdr args)) (stringify (car args)))
+    (t (string.append (stringify (car args)) (concat (cdr args)))) ))
 
 (defun load-script(fn)
   (load (concat script_dir "/" fn)))
@@ -62,6 +71,10 @@
 ;;
 ;;  Key Bindings, setkey is used to bind keys to user defined functions in lisp
 ;;
+
+(set-key "c-x @" "shell-command") ;; femto
+(set-key "esc !" "shell-command")
+(set-key "c-x i" "insert-file")
 
 (set-key "esc-right" "delete-next-word")
 (set-key "esc-left" "delete-previous-word")

--- a/key.c
+++ b/key.c
@@ -147,6 +147,7 @@ void setup_keys()
 	set_key_internal("c-w",     "kill-region"           , "\x17", kill_region);
 	set_key_internal("c-y",     "yank"                  , "\x19", yank);
 
+	set_key_internal("esc-!",   "shell-command"         , "\x1B\x21", user_func);
         set_key_internal("esc-a",   "apropos"               , "\x1B\x61", apropos);
 	set_key_internal("esc-b",   "backward-word"         , "\x1B\x62", backward_word);
 	set_key_internal("esc-c",   "copy-region"           , "\x1B\x63", copy_region);
@@ -174,7 +175,8 @@ void setup_keys()
 	set_key_internal("esc-<",     "beginning-of-buffer" , "\x1B\x3C", beginning_of_buffer);
 	set_key_internal("esc->",     "end-of-buffer"       , "\x1B\x3E", end_of_buffer);
 	set_key_internal("esc-]",     "eval-block"          , "\x1B\x5D", eval_block);
-	set_key_internal("esc-;",     "exec-lisp-command"   , "\x1B\x3B", repl);
+	set_key_internal("esc-:",     "exec-lisp-command"   , "\x1B\x3A", repl);
+	set_key_internal("esc-;",     "exec-lisp-command"   , "\x1B\x3B", repl); // femto
 	set_key_internal("esc-.",     "user-func"           , "\x1B\x2E", user_func);
 
 	set_key_internal("up ",       "previous-line",        "\x1B\x5B\x41", up);
@@ -199,11 +201,10 @@ void setup_keys()
 	set_key_internal("c-x =",     "cursor-position"       , "\x18\x3D", cursor_position);
 	set_key_internal("c-x ?",     "user-func"             , "\x18\x3F", user_func);
 	set_key_internal("c-x b",     "list-buffers"          , "\x18\x62", list_buffers);
-	set_key_internal("c-x i",     "insert-file"           , "\x18\x69", insertfile);
 	set_key_internal("c-x k",     "kill-buffer"           , "\x18\x6B", kill_buffer);
 	set_key_internal("c-x n",     "next-buffer"           , "\x18\x6E", next_buffer);
 	set_key_internal("c-x o",     "other-window"          , "\x18\x6F", other_window);
-	set_key_internal("c-x @",     "shell-command"         , "\x18\x40", i_shell_command);
+	set_key_internal("c-x @",     "user-func"             , "\x18\x40", user_func);
 	set_key_internal("c-x (",     "user-func"             , "\x18\x28", user_func);
 	set_key_internal("c-x )",     "user-func"             , "\x18\x29", user_func);
 	set_key_internal("c-x `",     "user-func"             , "\x18\x60", user_func);

--- a/lisp/femto.lsp
+++ b/lisp/femto.lsp
@@ -13,6 +13,34 @@
 (defun repeat (n func)  
   (cond ((> n 0) (func) (repeat (- n 1) func))))
 
+;; OS interaction
+;; Note: this emulates the original femto shell-command.
+;;   The move from C to Lisp allows implementation of more
+;;   powerful system interaction in the future
+(defun shell-command ()
+  (setq command (prompt-filename "Command: "))
+  (cond (command (shell-exec command))))
+
+(defun shell-exec (command)
+  (setq temp (get-temp-file))
+  (setq rc (system (concat command " > " temp " 2>&1 <&-")))
+  (cond
+    ((eq command ""))
+    ((or (eq rc -1) (eq rc 127))
+	(concat "error: failed to execute" command ": "  rc))
+    (t
+     (cond (not (eq rc 0)) (message "warning: " command " exited: " rc))
+     (select-buffer "*output*")
+     (erase-buffer)
+     (insert-file-contents-literally temp)
+     (system (concat "rm -f " temp))
+     (clear-message-line)
+     )))
+
+(defun insert-file ()
+  (setq fn (prompt-filename "Insert file: "))
+  (cond (fn (insert-file-contents-literally fn))))
+
 ;; trim all spaces from front of a string
 (defun string.trim.front(s)
   (cond


### PR DESCRIPTION
…bindings.

`shell-command` was not closing stdin, so it blocked when the sub process read from it.

Instead of fixing this in C code, a new primitive `system` is introduced. as the building block for arbitrary execution of subprocesses.

The new `shell-command` constructs the commandline from Lisp and simply adds " <&-" at the end which closes stdin.

Instead of implementing a string formatting library it was decided to make `concat` smarter, so it converts numbers to strings and traverses sublists.

A helper function `stringify` which takes one argument and tries to convert it to a string is used in `concat`.

Implementation of `prompt-filename` was incidential, but I guess it fit's well when trying to create a command line.

Since we needed to insert file content into the *output* buffer of `shell-command`, the C code `insert-file` was also replaced by a new primitive `insert-file-content-literally` and a Lisp level implementation of `insert-file`.

----
The new primitives give way for implementing Elisp like `call-process` and `call-process-region`.