### PR TITLE
Add batch and debug mode, select init_file, formatting, signal primitive

### DIFF
--- a/data.c
+++ b/data.c
@@ -5,6 +5,9 @@
 
 #include "header.h"
 
+int batch_mode = 0;
+int debug_mode = 0;
+
 int done;
 int result;
 int global_undo_mode = 1;

--- a/header.h
+++ b/header.h
@@ -182,6 +182,9 @@ extern command_t *cheadp;
  */
 #define MAX_SIZE_T      ((unsigned long) (size_t) ~0)
 
+extern int debug_mode;          /* Enable debugging */
+extern int batch_mode;          /* If True GUI is not run */
+
 extern int done;                /* Quit flag. */
 extern int msgflag;             /* True if msgline should be displayed. */
 extern int global_undo_mode;    /* True if we are undo mode is allowed by default */

--- a/lisp.c
+++ b/lisp.c
@@ -52,7 +52,6 @@ typedef long point_t;
 typedef struct Object Object;
 
 
-
 typedef enum Type {
 	TYPE_NUMBER,
 	TYPE_STRING,
@@ -1005,7 +1004,22 @@ Object *primitivePrinc(Object ** args, GC_PARAM)
 	return (*args)->car;
 }
 
-/************************* Editer Extensions **************************************/
+Object *primitiveSignal(Object ** args, GC_PARAM)
+{
+	Object *first = (*args)->car;
+	Object *second = (*args)->cdr->car;
+	
+	if (first->type != TYPE_SYMBOL)
+		exceptionWithObject(first , "is not a symbol");
+	if (second != nil && second->type != TYPE_CONS)
+		exceptionWithObject(second, "is not a list");
+
+	GC_TRACE(e, newCons(&first, &second, GC_ROOTS));
+	exceptionWithObject(*e, first->string);
+	return *e;
+}
+	
+/************************* Editor Extensions **************************************/
 
 #define DEFINE_EDITOR_FUNC(name) \
 extern void name(); \
@@ -1149,10 +1163,8 @@ Object *e_insert_file(Object ** args, GC_PARAM) {
 
 	mflag = (first->cdr != nil && first->cdr->car != nil);
 	mflag = FALSE;
-	if (insert_file(first->string, mflag) == TRUE)
-		return t;
-	else
-		return nil;
+
+	return ((insert_file(first->string, mflag) == TRUE) ? t : nil);
 }
 
 Object *e_getfilename(Object **args, GC_PARAM) {
@@ -1451,6 +1463,7 @@ Object *e_load(Object ** args, GC_PARAM)
 	if (first->type != TYPE_STRING)
 	    exceptionWithObject(first, "is not a string");
 
+	debug("(load %s)\n", first->string);
 	if ((fd = open(first->string, O_RDONLY)) == -1) {
 		snprintf(ebuf, 80, "failed to open %s\n", first->string);
 		ebuf[80] ='\0';
@@ -1630,6 +1643,7 @@ Primitive primitives[] = {
 	{"cons", 2, 2, primitiveCons},
 	{"print", 1, 1, primitivePrint},
 	{"princ", 1, 1, primitivePrinc},
+	{"signal", 2, 2, primitiveSignal},
 	{"+", 0, -1, primitiveAdd},
 	{"-", 1, -1, primitiveSubtract},
 	{"*", 0, -1, primitiveMultiply},
@@ -2032,14 +2046,15 @@ Object *newRootEnv(GC_PARAM, int arg, char **argv)
 	*gcVal = newString(*argv, GC_ROOTS);
 	argv++;
 	envSet(gcVar, gcVal, gcEnv, GC_ROOTS);
+
 	*gcVar = newSymbol("argv", GC_ROOTS);
-	*gcVal = nil;
+        *gcVal = nil;
 	Object **i = gcVal;
 	while(*argv) {
-	  *i = newCons(&nil, &nil, GC_ROOTS);
-	  (*i)->car = newString(*argv, GC_ROOTS);
-	  i = &(*i)->cdr;
-	  argv++;
+		*i = newCons(&nil, &nil, GC_ROOTS);
+		(*i)->car = newString(*argv, GC_ROOTS);
+		i = &(*i)->cdr;
+		argv++;
 	}
 	envSet(gcVar, gcVal, gcEnv, GC_ROOTS);
 
@@ -2074,11 +2089,17 @@ void set_input_stream_buffer(Stream *stream, char *buffer)
 void reset_output_stream()
 {
 	Stream *stream = &ostream; /* we only want 1 output stream */
-	stream->type = STREAM_TYPE_STRING;
-	stream->length = 0;
-	if (stream->buffer != NULL) {
-		free(stream->buffer);
+	if (batch_mode) {
+	  stream->type = STREAM_TYPE_FILE;
+	  stream->fd = STDOUT_FILENO;
+	  stream->buffer = NULL;
+	} else {
+	  stream->type = STREAM_TYPE_STRING;
+	  stream->length = 0;
+	  if (stream->buffer != NULL) {
+	    free(stream->buffer);
 		stream->buffer = NULL;
+	  }
 	}
 }
 
@@ -2152,19 +2173,26 @@ char *call_lisp(char *input)
 	assert(input != NULL);
 	Stream is = { .type = STREAM_TYPE_STRING };
 
-	//debug("START: call_lisp() '%s'\n", input);
+	debug("START: call_lisp() '%s'\n", input);
 	set_input_stream_buffer(&is, input);
 	call_lisp_body(theEnv, theRoot, &is);
-	//debug("END: call_lisp() '%s'\n", input);
+	debug("END: call_lisp() '%s'\n", input);
 	return ostream.buffer;
 }
 
 char *load_file(int infd)
 {
-	//debug("START: load_file fd=%d\n", infd);
+	debug("load_file(%d)\n", infd);
 	Stream input_stream = { .type = STREAM_TYPE_FILE, .fd = -1 };
-	set_stream_file(&input_stream, infd);
+        set_stream_file(&input_stream, infd);
 	load_file_body(theEnv, theRoot, &input_stream);
 	//debug("END: load_file fd=%d\n", infd);
 	return ostream.buffer;
 }
+
+/*
+ * Local Variables:
+ * c-basic-offset: 8
+ * indent-tabs-mode: t
+ * End:
+ */

--- a/main.c
+++ b/main.c
@@ -3,132 +3,177 @@
  * Derived from: Anthony's Editor January 93, (Public Domain 1991, 1993 by Anthony Howe)
  */
 
+#include <stdarg.h>
+#include <stdio.h>
+
 #include "header.h"
+
+void gui(); /* The GUI loop used in interactive mode */
 
 int main(int argc, char **argv)
 {
-	setup_keys();
-	(void)init_lisp(argc, argv);
+    batch_mode = (getenv("FEMTO_BATCH") != NULL);
+    debug_mode = (getenv("FEMTO_DEBUG") != NULL);
+  
+    /* buffers */
+    setlocale(LC_ALL, "") ; /* required for 3,4 byte UTF8 chars */
+    curbp = find_buffer(str_scratch, TRUE);
+    strncpy(curbp->b_bname, str_scratch, STRBUF_S);
+    beginning_of_buffer();
 
+    /* Lisp */
+    setup_keys();
+    (void)init_lisp(argc, argv);
+    load_config();
 
-	setlocale(LC_ALL, "") ; /* required for 3,4 byte UTF8 chars */
-	if (initscr() == NULL) fatal(f_initscr);
-	raw();
-	noecho();
-	idlok(stdscr, TRUE);
+    if (!batch_mode) gui();
 
-	start_color();
-	init_pair(ID_DEFAULT, COLOR_CYAN, COLOR_BLACK);          /* alpha */
-	init_pair(ID_SYMBOL, COLOR_WHITE, COLOR_BLACK);          /* non alpha, non digit */
-	init_pair(ID_MODELINE, COLOR_BLACK, COLOR_WHITE);        /* modeline */
-	init_pair(ID_DIGITS, COLOR_YELLOW, COLOR_BLACK);         /* digits */
-	init_pair(ID_BLOCK_COMMENT, COLOR_GREEN, COLOR_BLACK);   /* block comments */
-	init_pair(ID_LINE_COMMENT, COLOR_GREEN, COLOR_BLACK);    /* line comments */
-	init_pair(ID_SINGLE_STRING, COLOR_YELLOW, COLOR_BLACK);  /* single quoted strings */
-	init_pair(ID_DOUBLE_STRING, COLOR_YELLOW, COLOR_BLACK);  /* double quoted strings */
-	init_pair(ID_BRACE, COLOR_BLACK, COLOR_CYAN);            /* brace highlight */
-	
-	curbp = find_buffer(str_scratch, TRUE);
-	strncpy(curbp->b_bname, str_scratch, STRBUF_S);
+    debug("main(): shutdown\n");
+    // Note: exit frees all memory, do we need this here?
+    if (scrap != NULL) free(scrap);
+    return 0;
+}
 
-	wheadp = curwp = new_window();
-	one_window(curwp);
-	associate_b2w(curbp, curwp);
+void gui()
+{
+    debug("gui(): init\n");
+    if (initscr() == NULL) fatal(f_initscr);
+    raw();
+    noecho();
+    idlok(stdscr, TRUE);
 
-	beginning_of_buffer();
-	load_config();
+    start_color();
+    init_pair(ID_DEFAULT, COLOR_CYAN, COLOR_BLACK);          /* alpha */
+    init_pair(ID_SYMBOL, COLOR_WHITE, COLOR_BLACK);          /* non alpha, non digit */
+    init_pair(ID_MODELINE, COLOR_BLACK, COLOR_WHITE);        /* modeline */
+    init_pair(ID_DIGITS, COLOR_YELLOW, COLOR_BLACK);         /* digits */
+    init_pair(ID_BLOCK_COMMENT, COLOR_GREEN, COLOR_BLACK);   /* block comments */
+    init_pair(ID_LINE_COMMENT, COLOR_GREEN, COLOR_BLACK);    /* line comments */
+    init_pair(ID_SINGLE_STRING, COLOR_YELLOW, COLOR_BLACK);  /* single quoted strings */
+    init_pair(ID_DOUBLE_STRING, COLOR_YELLOW, COLOR_BLACK);  /* double quoted strings */
+    init_pair(ID_BRACE, COLOR_BLACK, COLOR_CYAN);            /* brace highlight */
 
-	while (!done) {
-		update_display();
-		input = get_key(khead, &key_return);
+    wheadp = curwp = new_window();
+    one_window(curwp);
+    associate_b2w(curbp, curwp);
 
-		if (key_return != NULL) {
-			(key_return->k_func)();
-		} else {
-			/*
-			 * if first char of input is a control char then
-			 * key is not bound, except TAB and NEWLINE
-			 */
-			if (*input > 31 || *input == 0x0A || *input == 0x09)
-				insert();
-                        else {
-				flushinp(); /* discard without writing in buffer */
-				msg(str_not_bound);
-			}
-		}
+    debug("gui(): loop\n");
+    while (!done) {
+        update_display();
+        input = get_key(khead, &key_return);
 
-		/* debug_stats("main loop:"); */
-		match_parens();
-	}
+        if (key_return != NULL)
+            (key_return->k_func)();
+        else {
+            /*
+             * if first char of input is a control char then
+             * key is not bound, except TAB and NEWLINE
+             */
+            if (*input > 31 || *input == 0x0A || *input == 0x09)
+                insert();
+            else {
+                flushinp(); /* discard without writing in buffer */
+                msg(str_not_bound);
+            }
+        }
 
-	if (scrap != NULL) free(scrap);
-	move(LINES-1, 0);
-	refresh();
-	noraw();
-	endwin();
-	return 0;
+        /* debug_stats("main loop:"); */
+        match_parens();
+    }
+    debug("gui(): shutdown\n");
+    move(LINES-1, 0);
+    refresh();
+    noraw();
+    endwin();
 }
 
 void fatal(char *msg)
 {
-	if (curscr != NULL) {
-		noraw();
-		endwin();
-	}
-	printf("\n%s %s:\n%s\n", E_NAME, E_VERSION, msg);
-	exit(1);
+    if (!batch_mode) {
+        if (curscr != NULL) {
+            noraw();
+            endwin();
+        }
+    }
+    printf("\n%s %s:\n%s\n", E_NAME, E_VERSION, msg);
+    exit(1);
 }
 
 void msg(char *m, ...)
 {
-	va_list args;
-	va_start(args, m);
-	(void) vsprintf(msgline, m, args);
-	va_end(args);
-	msgflag = TRUE;
+    va_list args;
+    va_start(args, m);
+    (void) vsprintf(msgline, m, args);
+    va_end(args);
+    msgflag = TRUE;
+
+    if (batch_mode) {
+        puts(msgline);
+        fflush(stdout);
+    }
 }
 
 void load_config()
 {
-	char *output;
-	int fd;
+    char *init_file;
+    char *output;
+    int fd;
 
-	reset_output_stream();
+    init_file = getenv("FEMTORC");
+    if (init_file == NULL)
+        init_file = E_INITFILE;
 
-	if ((fd = open(E_INITFILE, O_RDONLY)) == -1)
-		fatal("failed to open init file: " E_INITFILE);
-
-	reset_output_stream();
-	output = load_file(fd);
-	assert(output != NULL);
-	close(fd);
-
-	/* all exceptions start with the word error: */
-	if (NULL != strstr(output, "error:"))
-		fatal(output);
-	reset_output_stream();
+    debug("load_config(), init_file: %s\n", init_file);
+     
+    if ((fd = open(init_file, O_RDONLY)) == -1) {
+        (void)call_lisp("(message \"failed to open init file\")");
+    } else {
+        reset_output_stream();
+        output = load_file(fd);
+        close(fd);
+        //if (!batch_mode) {
+        assert(output != NULL);
+	   
+        /* all exceptions start with the word error: */
+        if (NULL != strstr(output, "error:"))
+            //  fatal(output);
+            (void)call_lisp("signal 'error-init '(\"init file throws exception\")");
+        //}
+        reset_output_stream();
+    }
 }
 
 void debug(char *format, ...)
 {
-	char buffer[256]; /* warning this is limited size, we should use vnsprintf */
+    char buffer[256];
 
-	va_list args;
-	va_start (args, format);
+    va_list args;
 
-	static FILE *debug_fp = NULL;
+    if (!debug_mode) return;
+     
+    va_start (args, format);
 
-	if (debug_fp == NULL) {
-		debug_fp = fopen("debug.out","w");
-	}
+    static FILE *debug_fp = NULL;
 
-	vsprintf (buffer, format, args);
-	va_end(args);
+    if (debug_fp == NULL)
+        debug_fp = fopen("debug.out","w");
 
-	fprintf(debug_fp,"%s", buffer);
-	fflush(debug_fp);
+    vsnprintf (buffer, sizeof(buffer), format, args);
+    va_end(args);
+
+    fprintf(debug_fp,"%s", buffer);
+    fflush(debug_fp);
 }
 
-void debug_stats(char *s) {
-	debug("%s bsz=%d p=%d m=%d gap=%d egap=%d\n", s, curbp->b_ebuf - curbp->b_buf, curbp->b_point, curbp->b_mark, curbp->b_gap - curbp->b_buf, curbp->b_egap - curbp->b_buf);
+void debug_stats(char *s)
+{
+    debug("%s bsz=%d p=%d m=%d gap=%d egap=%d\n", s, curbp->b_ebuf - curbp->b_buf, curbp->b_point, curbp->b_mark, curbp->b_gap - curbp->b_buf, curbp->b_egap - curbp->b_buf);
 }
+
+/*
+ * Local Variables:
+ * c-file-style: "k&r"
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */


### PR DESCRIPTION
# Batch Mode

When the environment variable FEMTO_BATCH exists, `femto` runs in batch mode:
- GUI is not started
- All Lisp output is sent to stdout

# Debug Mode

When the environment variable FEMTO_DEBUG exists, `femto` turns on debugging. Some details of the inner working are logged to the file `debug.out`.

# Select init_file at runtime

When the environment variable FEMTORC is set, `femto` interprets its value as the path to the init file and tries to load it instead of the default init_file.

# Other Changes

## Formatting

Femto coding style will be K&R with 4 space indents, with exception of `lisp.c` which remains with tab indents.  `main.c` has been reformatted.

 ## main.c

Has been restructured completely so that GUI relevant functionality can be separated from other logic.

load_config() does not `fatal`ly exit when it fails, instead an error is shown in the message area.  Femto can work very well without the initialization file.

debug() got its `vsnprintf` for which it has asked already in a comment.

## lisp.c

A new primitive `(signal 'error-symbol error-details)` has been added.  It throws an exception. The interface is built analogous to Elisp.  It was just used for testing, but might be useful in the future anyway.

# Motivation

Batch mode and init file selection will make unit testing easier.

Init file selection (and debug mode) will simplify debugging of startup problems.