### PR TITLE
Check in the generated flisp.md document

### DIFF
--- a/docs/flisp.md
+++ b/docs/flisp.md
@@ -1,0 +1,674 @@
+# fLisp Manual
+
+### Introduction
+
+*fLisp* is a tiny yet practical interpreter for a dialect of the Lisp
+programming language. It is used as extension language for the
+[Femto](https://github.com/matp/tiny-lisp) text editor.
+
+*fLisp* originates from [Tiny-Lisp by
+matp](https://github.com/matp/tiny-lisp) (pre 2014), was integrated into
+[Femto](https://github.com/hughbarney/femto) by Hugh Barnes (pre 2016)
+and compacted by Georg Lehner in 2023.
+
+> A designer knows he has achieved perfection not when there is nothing
+> left to add, but when there is nothing left to take away.
+>
+> — Antoine de Saint-Exupery
+
+### Lisp
+
+#### Notation Convention
+
+fLisp fancies to converge toward Emacs Lisp. Functions descriptions are
+annoted with a compatibility scale:
+
+<u>C</u>  
+Interface compatible, though probably less featureful.
+
+<u>D</u>  
+Same name, but different behavior.
+
+<u>S: `name`</u>  
+`name` is a similar but not compatible function in Emacs Lisp.
+
+<u>B</u>  
+Buggy/incompatible implementation.
+
+Annotation is omitted if the function does not exist in Emacs Lisp.
+
+#### fLisp Interpreter
+
+When *fLisp* is invoked it follows a three step process:
+
+1.  Read: program text is read in and converted into an internal
+    representation.
+2.  Evaluate: the internal representation is evaluated
+3.  Print: the result of the evaluation is returned to the invoker.
+
+Core functions of the language operate on internal objects only. The
+interpreter is extended with additional functions in order to interact
+with external objects.  With respect to the interpreter, extension
+functions behave the same as core functions.
+
+#### Syntax
+
+Program text is written as a sequence of symbolic expressions -
+<span class="dfn">sexp</span>'s in parenthesized form. A sexp is either
+a single object or a function invocation enclosed in parens. Function
+invocations can be infinitely nested.
+
+The following characters are special to the reader:
+
+`(`  
+Starts a function invocation, *list* or *cons* object (see "Objects and
+Data Types").  
+ 
+
+`)`  
+Finishes a function invocation, *list* or *cons* object.  
+ 
+
+`"`  
+Encloses strings.  
+ 
+
+`'`  
+With a single quote prefix before a *sexp*, the *sexp* is expanded to
+`(quote ``sexp``)` before it is evaluated.
+
+`.`  
+The expresion` (``a`` . ``b``)` evaluates to a *cons* object, holding
+the objects `a` and `b`.
+
+Numbers are represented in decimal notation.
+
+A list of objects has the form:
+
+> `(`\[`element` ..\]`)`
+
+A function invocation has the form:
+
+> `(``name`` `\[`param`` `..\]`)`
+
+There are two predefined objects. Their symbols are:
+
+`nil`  
+represents: the empty list: (), the end of a list marker or the false
+value in logical operations.  
+ 
+
+`t`  
+a fixed, non-false value.
+
+#### Objects and Data Types
+
+*fLisp* objects have exactly one of the following data types:
+
+<span class="dfn">number</span>  
+[double precision floating point
+number.](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)
+
+<span class="dfn">string</span>  
+character array.
+
+<span class="dfn">cons</span>  
+object holding two pointers to objects.
+
+<span class="dfn">symbol</span>  
+string with restricted character set:
+`[A-Z][0-9][a-z]!#$%&*+-./:<=>?@^_~`
+
+<span class="dfn">lambda</span>  
+anonymous function with parameter evaluation
+
+<span class="dfn">macro</span>  
+anonymous function without parameter evaluation
+
+Objects are unmutable, all fLisp functions create new objects from
+existing ones.
+
+Characters do not have their own type. A single character is represented
+by a *string* with length 1.
+
+#### Symbols, Environments and Functions
+
+All operations of the interpreter take place in a root environment. An
+<span class="dfn">environment</span> is a collection of named objects.
+The object names have the `symbol` datatype.
+
+`lambda` and `macro` objects are functions. They have a parameter list
+and a body. When they are invoked, they receive zero or more named
+objects, bind them one by one to the symbols in the paramter list,
+evaluate the body and return a result.
+
+When a function executed within the function body want's to use a named
+object it is first looked up in the new environment, and then
+recursively in the environments from which the `lambda` or `macro` was
+invoked.
+
+`lambda`s evaluate each parameter then create a new environment
+containing the parameters before evaluating the body.
+
+*macros* evaluate the body which typically returns a new expresions in
+terms of the parameters. The expression is then evaluated in a new
+environment containing the parameters.
+
+#### Functions
+
+##### Interpreter
+
+`(progn` \[`expr` ..\]`)`  
+Each `expr` is evaluated, the value of the last is returned.  
+ 
+
+`(cond` \[`clause` ..\]`)`  
+Each `clause` is of the form `(``pred`` [``action``])`. `cond` evaluates
+each `clause` in turn: if `pred` evaluates to `nil`, the next `clause`
+is tested. Otherwise: if there is no `action` the value of `pred` is
+returned, otherwise `(progn ``action``)` is returned and no more
+`clause`s are evaluated.
+
+`(setq ``symbol`` ``value` \[`symbol`` ``value`\]..`)`  
+Create or update named objects: If `symbol` is the name of an existing
+named object in the current or a parent environment the named object is
+set to `value`, if no symbol with this name exists, a new one is created
+in the current environment. `setq` returns the last `value`.
+
+`(lambda ``params`` ``body``)`  
+Returns a `lambda` function which accepts 0 or more arguments, which are
+passed as list in the parameter `params`.
+
+`(lambda (`\[`param` ..\]`) ``body``)`  
+Returns a `lambda` function which accepts the exact number of arguments
+given in the list of `param`s.
+
+`(lambda (``param` \[`param` ..\]` . opt)`  
+Returns a `lambda` function which requires at least the exact number of
+arguments given in the list of `param`s. All extra arguments are passed
+as a list in the parameter `opt`.
+
+`(macro ``params`` ``body``)`  
+These forms return a `macro` function with the same parameter handling
+as with `lambda`.
+
+`(macro (`\[`param` ..\]`) ``body``)`  
+\-
+
+`(macro (``param` \[`param` ..\]` . opt)`  
+\-
+
+`(quote ``expr``)`  
+quote returns `expr` without evaluating it.  
+ 
+
+(signal symbol list)  
+tbd
+
+(trap list)  
+tbd
+
+   
+ 
+
+##### Objects
+
+`(null ``object``)`
+
+Returns `t` if `object` is `nil`, otherwise `nil`.
+
+`(symbolp ``object``)`<span style="display: none;"> </span><span style="display: none;"> </span>
+
+Returns `t` if `object` is of type *symbol, *otherwise `nil`.
+
+`(symbol-name ``object``)`
+
+If `object` is of type *symbol* return its value as string.
+
+`(numberp ``object``)`
+
+Returns `t` if `object` is of type *number*, otherwise `nil`.
+
+`(stringp ``object``)` Returns `t` if `object` is of type *string*,
+otherwise `nil`.
+
+ 
+
+`(consp ``object``)`
+
+Returns `t` if `object` is of type *cons*, otherwise `nil`.
+
+`(cons ``car`` ``cdr``)`
+
+Returns a new *cons* with the first object set to the value of `car` and
+the second to the value of `cdr`.
+
+`(car ``cons``)`
+
+Returns the first object of `cons`.
+
+`(cdr ``cons``)`
+
+Returns the second object of `cons`.
+
+`(eq ``a`` ``b``)`
+
+Returns `t` if `a` and `b` evaluate to the same object, `nil` otherwise.
+
+`(print ``object``)`
+
+Formats `object` into a string which can be read by the reader and
+returns it. As a side effect, the string is printed to the output stream
+with a leading and a closing newline. `print` escapes quotes in strings
+with a backslash.
+
+`(princ ``object``)`
+
+Formats `object` into a string and returns it, As a side effect, the
+string is printed to the output stream.
+
+##### String operations
+
+`(string.length ``string``)`
+
+Returns the length of `string` as a *number*.
+
+ 
+
+`(string.substring ``string`` ``start`` ``end``)`
+
+Returns the substring from `string` which starts with the character at
+index `start` and ends with index `end`. String indexes are zero based.
+
+`(string.append ``string1`` ``string2``)`
+
+Returns a new string consisting of the concatenation of `string1` with
+`string2`.  
+ 
+
+`(string-to-number ``string``)`
+
+Converts `string` into a corresponding *number* object. String is
+interpreted as decimal based integer.
+
+`(number-to-string number)`
+
+Converts `number` into a *string* object.  
+ 
+
+`(ascii ``number``)`
+
+Converts `number` into a *string* with one character, which corresponds
+to the ASCII representation of `number`.  
+ 
+
+`(ascii->number ``string``)`
+
+Converts the first character of `string` into a *number* which
+corresponds to its ASCII value.
+
+ 
+
+##### Arithmetic Operations
+
+`(+` \[`arg` ..\]`)`  
+Returns the sum of all `arg`s or `0` if none given.
+
+`(*` \[`arg` ..\]`)`  
+Returns the product of all `arg`s or `1` if none given.
+
+`(-` \[`arg` ..\]`)`  
+Returns 0 if no `arg` is given, -`arg` if only one is given, `arg` minus
+the sum of all others otherwise.
+
+`(/ ``arg` \[`div` ..\]`)`  
+Returns 1/`arg` if no `div` is given, `arg`/`div`\[/`div`../\] if one or
+more `div`s are given, `inf` if one of the `div`s is `0` and the sum of
+the signs of all operands is even, `-inf` if it is odd.
+
+`(% ``arg` \[`div` ..\]`)`  
+Returns `1` if no `div` is given, `arg`%`div`\[%`div` ..\] if one or
+more `div`s are given. If one of the divs is `0`, the program exits with
+an arithmetic exception.
+
+`(= ``arg` \[`arg` ..\]`)`  
+\-  
+ 
+
+`(< ``arg` \[`arg` ..\]`)`  
+\-  
+ 
+
+`(> ``arg` \[`arg` ..\]`)`  
+\-  
+ 
+
+`(<= ``arg` \[`arg` ..\]`)`  
+\-  
+ 
+
+`(>= ``arg` \[`arg` ..\]`)`  
+These predicate functions apply the respective comparison operator
+between all `arg`s and return the respective result as `t` or `nil`.
+
+### Editor Extensions
+
+#### Buffers
+
+Buffers store text and allow to manipulate it. A buffer has the
+following properties:
+
+`Name`  
+Buffers are identified by their name. If a buffer name is enclosed in
+\*asterisks\* the buffer receives special treatment.
+
+`Text`  
+0 or more characters.
+
+`Point`  
+The position in the text where text manipulation takes place.
+
+`Mark`  
+An optional second position in the text. If the `mark` is set, the text
+between `point` and `mark` is called the
+<span class="dfn">selection</span> or <span class="dfn">region</span>.
+
+`Filename`  
+A buffer can be associated with a file.
+
+`Flags`  
+Different flags determine the behaviour of the buffer.
+
+This section describes the buffer related functions added by Femto to
+fLisp. The description is separated in function related to buffer
+management and text manipulation. Buffer management creates, deletes
+buffers, or selects one of the existing buffers as the “current” buffer.
+Text manipulation always operates on the current buffer.
+
+Femto provides a single temporary string storage named
+<span class="dfn">clipboard</span> to support text manipulation.
+
+##### Text manipulation
+
+`(insert-string ``string``)`  
+Inserts `string` at *point*. <u>S: insert</u>.
+
+`(insert-file-contents-literally ``string`` `\[`flag`\]`)`  
+Inserts the file `string` after *point*. If `flag` is not nil the buffer
+is marked as not modified. <u>B</u>
+
+Note: Currently the flag is forced to nil. The function should return
+`(``filename`` ``count``)` but it returns a flag indicating if the
+operation succeeded.
+
+`(erase-buffer)`  
+Erases all text in the current buffer. <u>C</u>
+
+`(delete)`  
+Deletes the character after *point*. <u>S: delete-char</u>
+
+`(backspace)`  
+Deletes the character to the left of *point*.
+<u>S: delete-backward-char</u>
+
+`(get-char)`  
+Returns the character to the left of *point*. <u>S: get-byte</u>
+
+`(copy-region)`  
+Copies *region* to the *clipboard*. <u>S: copy-region-as-kill</u>
+
+`(kill-region)`  
+Deletes the text in the *region* and copies it to the *clipboard*.
+<u>D</u>
+
+`(yank)`  
+Pastes the *clipboard* before *point*. <u>C</u>
+
+##### Selection
+
+(set-mark)  
+Sets `mark` to `point`. <u>D</u>
+
+(get-mark)  
+Returns the position of `mark`, -1 if `mark` is unset. <u>S: mark</u>
+
+(get-point)  
+Returns the position of `point`. <u>S: point</u>
+
+(get-point-max)  
+Returns the maximum accessible value of point in the current buffer.
+<u>S: point-max</u>
+
+`(set-clipboard ``variable``)`  
+`Sets `*`clipboard`*` to the contents of ``variable``.` <u>S: gui-set-selection</u>
+
+`(get-clipboard)`  
+Returns the *clipboard* contents.  <u>S: gui-get-selection</u>
+
+##### Cursor Movement
+
+`(set-point ``number``)`  
+Sets the point to in the current buffer to the position `number`. <u>S:
+goto-char</u>
+
+`(goto-line ``number``)`  
+Sets the point in the current buffer to the first character on line
+`number`. <u>S: goto-line</u>, not an Elisp function.
+
+`(search-forward ``string``)`  
+Searches for `string` in the current buffer, starting from point
+forward. If string is found, sets the point after the first occurrence
+of `string` and returns `t`, otherwise leaves point alone and returns
+`nil`. <u>D</u>
+
+`(search-backward ``string``)`  
+Searches for `string` in the current buffer, starting from point
+backwards. If string is found, sets the point before the first
+occurrence of `string` and returns `t`, otherwise leaves point alone and
+returns `nil`. <u>D</u>
+
+`(beginning-of-buffer)`  
+Sets the point in the current buffer to the first buffer position,
+leaving mark in its current position. <u>C</u>
+
+`(end-of-buffer)`  
+Sets the point in the current buffer to the last buffer position,
+leaving mark in its current position. <u>C</u>
+
+`(beginning-of-line)`  
+Sets point before the first character of the current line, leaving mark
+in its current position. <u>S: move-beginning-of-line</u>
+
+`(end-of-line)`  
+Sets point after the last character of the current line, i.e. before the
+end-of-line character sequence, leaving mark in its current position.
+<u>S: move-end-of-line</u>
+
+`(forward-word)`  
+Moves the point in the current buffer forward before the first char of
+the next word. If there is no word left the point is set to the end of
+the buffer. If the point is already at the start or within a word, the
+current word is skipped. <u>D</u>: **Note**: Elisp moves to the *end* of
+the the next word.
+
+`(backward-word)`  
+Moves the point in the current buffer backward after the last char of
+the previous word. If there is no word left the point is set to the
+beginning of the buffer. If the point is already at the end or within a
+word, the current word is skipped. <u>D</u>: **Note**: Elisp moves to
+the *beginning* of the previous word.
+
+`(forward-char)`  
+Moves the point in the current buffer one character forward, but not
+past the end of the buffer. <u>C</u>
+
+`(backward-char)`  
+Moves the point in the current buffer one character backward, but not
+before the end of the buffer. <u>C</u>
+
+`(forward-page)`  
+Moves the point of the current buffer to the beginning of the last
+visible line of the associated screen and scrolls the screen up to show
+it as the first line. <u>S: scroll-up</u>
+
+`(backward-page)`  
+Moves the point of the current buffer to the beginning of the first
+visible line of the associoated screen and scrolls the screen down to
+show it as the last line. <u>S: scroll-down</u>
+
+`(next-line)`  
+Moves the point in the current buffer to the same character position in
+the next line, or to the end of the next line if there are not enough
+characters. In the last line of the buffer moves the point to the end of
+the buffer. <u>C</u>
+
+`(previous-line)`  
+Movest the point in the current buffer to the same character position in
+the previous line, or to the end of the previous line if there are not
+enough characters. In the first line of the buffer the point is not
+moved. <u>C</u>
+
+##### Buffer management
+
+`(list-buffers)`  
+Lists all the buffers in a buffer called `*buffers*`.
+
+`(get-buffer-count)`  
+Returns the number of buffers, includes all special buffers and
+`*buffers*`.
+
+`(select-buffer ``string``)`  
+Makes the buffer named `string` the current buffer. Note: <u>C</u> to
+`set-buffer` in Elisp.
+
+`(rename-buffer ``string``)`  
+Rename the current buffer to `string`. <u>C</u>
+
+`(kill-buffer ``string``)`  
+Kill the buffer names `string`. Unsaved changes are discarded. <u>C</u>
+
+`(get-buffer-name)`  
+Return the name of the current buffer. Note: <u>C</u> to `buffer-name`
+in Elisp.
+
+`(add-mode-global ``string``)`  
+Sets global mode `string` for all buffers. Currently the only global
+mode is <span class="kbd">undo</span>.
+
+`(find-file ``string``)`  
+Loads file with path string into a new buffer. <u>C</u>
+
+`(save-buffer ``string``)`  
+Saves the buffer named `string` to disk. <u>C</u>
+
+#### User Interaction
+
+`(message ``string``)`  
+Displays `string` in the message line. <u>D</u> 
+
+`(clear-message-line)`  
+Displays the empty string in the message line.
+
+`(prompt ``prompt`` ``default``)`  
+Displays `prompt` in the command line and sets `default` as initial
+value for the user respones. The user can edit the response. When
+hitting return, the final response is returned.
+
+`(show-prompt ``prompt`` ``default``)`  
+Displays `prompt` and `default` in the commandline, but does not allow
+editing. Returns `t`.
+
+`(prompt-filename ``prompt``)`  
+Displays `prompt` in the commandline and allows to enter or search for a
+file name. Returns the relative path to the selected file name or the
+response typed by the user.
+
+`(getch)`  
+Waits for a key to be pressed and returns the key as string. See also
+`get-key-name`, `get-key-funcname` and `execute-key`.
+
+(exit)  
+Exit Femto without saving modified buffers.
+
+##### Keyboard Handling
+
+`(set-key ``key-name`` ``lisp-func``)`  
+Binds key key-name to the lisp function `lisp-func`.
+
+`(get-key-name)`  
+Returns the name of the currently pressed key, eg: `c-k` for control-k.
+
+`(get-key-funcname)`  
+Return the name of the function bound to the currently pressed key.
+
+`(execute-key)`  
+Executes the function of the last bound key.
+<span class="mark">Tbd. bound or pressed?</span>
+
+`(describe-bindings)`  
+Creates a listing of all current key bindings, in a buffer named
+`*help*` and displays it in a new window. <u>C</u>
+
+`(describe-functions)`  
+Creates a listing of all functions bound to keys in a buffer named
+`*help*` and displays it in a new window.
+
+##### Window Handling
+
+`(delete-other-windows)`  
+ Make current window the only window. <u>C</u>  
+ 
+
+`(split-window)`  
+Splits the current window. Creates a new window for the current buffer.
+<u>C</u>
+
+`(other-window)`  
+Moves the cursor to the next window down on the screen. Makes the buffer
+in that window the current buffer. <u>D</u>
+
+Note: Elisp `other-window` has a required parameter `count`, which
+specifies the number of windows to move down or up.
+
+`(update-display)`  
+Updates all modified windows.
+
+`(refresh)`  
+Updates all windows by marking them modified and calling
+`update-display`.
+
+##### Programming and System Interaction
+
+`(eval-block)`
+
+Evaluates the `region` in the current buffer, inserts the result at
+`point` and returns it. If `mark` in the current buffer is before
+`point` `eval-block` evaluates this `region` and inserts the result at
+`point`. If `point` is before `mark` `eval-block` does nothing but
+returning `t`.
+
+`(system ``string``)`
+
+Executes the
+[system(1)](https://man7.org/linux/man-pages/man3/system.3.html)
+function with `string` as parameter.
+
+`(os.getenv ``string``) `
+
+Returns the value of the environment variable named `string`.
+
+`(log-message ``string``)`
+
+Logs `string` to the `*messages*` buffer. 
+
+`(log-debug ``string``)`
+
+Logs string to the file `debug.out`.
+
+`(get-version-string)`
+
+Returns the complete version string of Femto, including the copyright.
+
+### Implementation Details
+
+<span class="mark">Tbd.: Memory consumption, limits, hacking, ...</span>

--- a/docs/flisp.md
+++ b/docs/flisp.md
@@ -2,25 +2,34 @@
 
 ### Introduction
 
-*fLisp* is a tiny yet practical interpreter for a dialect of the Lisp
-programming language. It is used as extension language for the
-[Femto](https://github.com/matp/tiny-lisp) text editor.
-
-*fLisp* originates from [Tiny-Lisp by
-matp](https://github.com/matp/tiny-lisp) (pre 2014), was integrated into
-[Femto](https://github.com/hughbarney/femto) by Hugh Barnes (pre 2016)
-and compacted by Georg Lehner in 2023.
-
 > A designer knows he has achieved perfection not when there is nothing
 > left to add, but when there is nothing left to take away.
 >
 > — Antoine de Saint-Exupery
 
+*fLisp* is a tiny yet practical interpreter for a dialect of the Lisp
+programming language. It is used as extension language for the
+[Femto](https://github.com/matp/tiny-lisp) text editor.
+
+*fLisp* originates from [Tiny-Lisp by
+matp](https://github.com/matp/tiny-lisp) (pre 2014), was integrated into
+[Femto](https://github.com/hughbarney/femto) by Hugh Barnes (pre 2016)
+and compacted by Georg Lehner in 2023.
+
+This is a reference manual. If you want to learn about Lisp programming
+use other resources eg.
+
+- The [Common Lisp](lisp-lang.org) web site,
+- [An Introduction to Programming in Emacs
+  Lisp](https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html)
+  or
+- [The Scheme Programming Language](https://www.scheme.org/).
+
 ### Lisp
 
 #### Notation Convention
 
-fLisp fancies to converge toward Emacs Lisp. Functions descriptions are
+*fLisp* fancies to converge toward Emacs Lisp. Function descriptions are
 annoted with a compatibility scale:
 
 <u>C</u>  
@@ -46,46 +55,43 @@ When *fLisp* is invoked it follows a three step process:
 2.  Evaluate: the internal representation is evaluated
 3.  Print: the result of the evaluation is returned to the invoker.
 
-Core functions of the language operate on internal objects only. The
-interpreter is extended with additional functions in order to interact
-with external objects.  With respect to the interpreter, extension
-functions behave the same as core functions.
+Core functions of the language operate on built-in objects only. *fLisp*
+is extended with additional functions in order to interact with editor
+related objects. With respect to the interpreter, extension functions
+behave the same as core functions.
 
 #### Syntax
 
 Program text is written as a sequence of symbolic expressions -
-<span class="dfn">sexp</span>'s in parenthesized form. A sexp is either
-a single object or a function invocation enclosed in parens. Function
-invocations can be infinitely nested.
+<span class="dfn">sexp</span>'s - in parenthesized form. A sexp is
+either a single object or a function invocation enclosed in parens.
+Function invocations can be infinitely nested.
 
 The following characters are special to the reader:
 
 `(`  
-Starts a function invocation, *list* or *cons* object (see "Objects and
-Data Types").  
- 
+Starts a function invocation, *list* or *cons* object (see [Objects and
+Data Types](#objects_and_data_types)).
 
 `)`  
-Finishes a function invocation, *list* or *cons* object.  
- 
+Finishes a function invocation, *list* or *cons* object
 
 `"`  
-Encloses strings.  
- 
+Encloses strings.
 
 `'`  
-With a single quote prefix before a *sexp*, the *sexp* is expanded to
+With a single quote prefix before a sexp, the sexp is expanded to
 `(quote ``sexp``)` before it is evaluated.
 
 `.`  
-The expresion` (``a`` . ``b``)` evaluates to a *cons* object, holding
+The expresion` (``a`` . ``b``)` evaluates to a *cons* object, holding
 the objects `a` and `b`.
 
 Numbers are represented in decimal notation.
 
 A list of objects has the form:
 
-> `(`\[`element` ..\]`)`
+> `(`\[`element`..\]`)`
 
 A function invocation has the form:
 
@@ -94,12 +100,11 @@ A function invocation has the form:
 There are two predefined objects. Their symbols are:
 
 `nil`  
-represents: the empty list: (), the end of a list marker or the false
-value in logical operations.  
- 
+represents: the empty list: `()`, the end of a list marker or the false
+value in logical operations.
 
 `t`  
-a fixed, non-false value.
+“true”, a fixed, non-false value.
 
 #### Objects and Data Types
 
@@ -125,46 +130,57 @@ anonymous function with parameter evaluation
 <span class="dfn">macro</span>  
 anonymous function without parameter evaluation
 
-Objects are unmutable, all fLisp functions create new objects from
-existing ones.
+Objects are unmutable, all *fLisp* functions create new objects from
+existing ones or return existing ones.
 
 Characters do not have their own type. A single character is represented
 by a *string* with length 1.
 
-#### Symbols, Environments and Functions
+#### Environments, Functions, Evaluation
 
-All operations of the interpreter take place in a root environment. An
+All operations of the interpreter take place in an environment. An
 <span class="dfn">environment</span> is a collection of named objects.
-The object names have the `symbol` datatype.
+The object names have the `symbol` datatype. An object in an environment
+is said to be <span class="dfn">bound</span> to its name. Environments
+can have a parent. Each *fLisp* interpreter starts with a
+<span class="dfn">root</span> environment without a parent.
 
-`lambda` and `macro` objects are functions. They have a parameter list
-and a body. When they are invoked, they receive zero or more named
-objects, bind them one by one to the symbols in the paramter list,
-evaluate the body and return a result.
+*lambda* and *macro* objects are functions. They have a parameter list
+and a *sexp* as body. When functions are invoked a new environment is
+created as child of the current environment.
 
-When a function executed within the function body want's to use a named
-object it is first looked up in the new environment, and then
-recursively in the environments from which the `lambda` or `macro` was
-invoked.
+Functions receive zero or more objects from the caller. These are bound
+one by one to the symbols in the parameter list in the new environment.
 
-`lambda`s evaluate each parameter then create a new environment
-containing the parameters before evaluating the body.
+*lambda*s return the result of evaluating the body in the new
+environment.
 
-*macros* evaluate the body which typically returns a new expresions in
-terms of the parameters. The expression is then evaluated in a new
-environment containing the parameters.
+*macro*s first evaluate the body in the calling environment. The
+resulting *sexp* is evaluated in the new environment and that result is
+returned.
 
-#### Functions
+*macro* bodies typically are crafted to return new *sexp*s in terms of
+the parameters.
 
-##### Interpreter
+When a *sexp* is evaluated and encounters a *symbol* it looks it up in
+the current environment, and then recursively in the environments from
+which the `lambda` or `macro` was invoked. The symbol of the first
+binding is then replaced by its object.
+
+*fLisp* counts with a set of built-in functions called
+<span class="dfn">primitives</span>. They are grouped in the manual by
+the type of objects they operate on.
+
+#### Primitives
+
+##### Interpreter Operations
 
 `(progn` \[`expr` ..\]`)`  
-Each `expr` is evaluated, the value of the last is returned.  
- 
+Each `expr` is evaluated, the value of the last is returned.
 
 `(cond` \[`clause` ..\]`)`  
 Each `clause` is of the form `(``pred`` [``action``])`. `cond` evaluates
-each `clause` in turn: if `pred` evaluates to `nil`, the next `clause`
+each `clause` in turn: if `pred` evaluates to `nil`, the next `clause`
 is tested. Otherwise: if there is no `action` the value of `pred` is
 returned, otherwise `(progn ``action``)` is returned and no more
 `clause`s are evaluated.
@@ -175,151 +191,116 @@ named object in the current or a parent environment the named object is
 set to `value`, if no symbol with this name exists, a new one is created
 in the current environment. `setq` returns the last `value`.
 
-`(lambda ``params`` ``body``)`  
+`(lambda ``params`` ``body``)`  
 Returns a `lambda` function which accepts 0 or more arguments, which are
 passed as list in the parameter `params`.
 
 `(lambda (`\[`param` ..\]`) ``body``)`  
 Returns a `lambda` function which accepts the exact number of arguments
-given in the list of `param`s.
+given in the list of `param`s.
 
-`(lambda (``param` \[`param` ..\]` . opt)`  
+`(lambda (``param` \[`param` ..\]` . ``opt``) ``body``)`  
 Returns a `lambda` function which requires at least the exact number of
 arguments given in the list of `param`s. All extra arguments are passed
 as a list in the parameter `opt`.
 
-`(macro ``params`` ``body``)`  
-These forms return a `macro` function with the same parameter handling
-as with `lambda`.
-
+`(macro ``params`` ``body``)`  
 `(macro (`\[`param` ..\]`) ``body``)`  
-\-
-
-`(macro (``param` \[`param` ..\]` . opt)`  
-\-
+`(macro (``param` \[`param` ..\]` . ``opt``) ``body``)`  
+These forms return a `macro` function. Parameter handling is the same as
+with `lambda`.
 
 `(quote ``expr``)`  
-quote returns `expr` without evaluating it.  
- 
+quote returns `expr` without evaluating it.
 
-(signal symbol list)  
+`(signal ``symbol`` ``list``)`  
 tbd
 
-(trap list)  
+`(trap ``list``)`  
 tbd
 
-   
- 
+##### Object Operations
 
-##### Objects
+`(null ``object``)`  
+Returns `t` if `object` is `nil`, otherwise `nil`.
 
-`(null ``object``)`
+`(symbolp ``object``)`  
+Returns `t` if `object` is of type *symbol,* otherwise `nil`.
 
-Returns `t` if `object` is `nil`, otherwise `nil`.
-
-`(symbolp ``object``)`<span style="display: none;"> </span><span style="display: none;"> </span>
-
-Returns `t` if `object` is of type *symbol, *otherwise `nil`.
-
-`(symbol-name ``object``)`
-
+`(symbol-name ``object``)`  
 If `object` is of type *symbol* return its value as string.
 
-`(numberp ``object``)`
+`(numberp ``object``)`  
+Returns `t` if `object` is of type *number*, otherwise `nil`.
 
-Returns `t` if `object` is of type *number*, otherwise `nil`.
+`(stringp ``object``)`  
+Returns `t` if `object` is of type *string*, otherwise `nil`.
 
-`(stringp ``object``)` Returns `t` if `object` is of type *string*,
-otherwise `nil`.
-
- 
-
-`(consp ``object``)`
-
+`(consp ``object``)`  
 Returns `t` if `object` is of type *cons*, otherwise `nil`.
 
-`(cons ``car`` ``cdr``)`
-
+`(cons ``car`` ``cdr``)`  
 Returns a new *cons* with the first object set to the value of `car` and
 the second to the value of `cdr`.
 
-`(car ``cons``)`
-
+`(car ``cons``)`  
 Returns the first object of `cons`.
 
-`(cdr ``cons``)`
-
+`(cdr ``cons``)`  
 Returns the second object of `cons`.
 
-`(eq ``a`` ``b``)`
-
+`(eq ``a`` ``b``)`  
 Returns `t` if `a` and `b` evaluate to the same object, `nil` otherwise.
 
-`(print ``object``)`
-
+`(print ``object``)`  
 Formats `object` into a string which can be read by the reader and
 returns it. As a side effect, the string is printed to the output stream
-with a leading and a closing newline. `print` escapes quotes in strings
+with a leading and a closing newline. `print` escapes quotes in strings
 with a backslash.
 
-`(princ ``object``)`
-
+`(princ ``object``)`  
 Formats `object` into a string and returns it, As a side effect, the
 string is printed to the output stream.
 
-##### String operations
+##### String Operations
 
-`(string.length ``string``)`
-
+`(string.length ``string``)`  
 Returns the length of `string` as a *number*.
 
- 
-
-`(string.substring ``string`` ``start`` ``end``)`
-
-Returns the substring from `string` which starts with the character at
+`(string.substring ``string`` ``start`` ``end``)`  
+Returns the substring from `string` which starts with the character at
 index `start` and ends with index `end`. String indexes are zero based.
 
-`(string.append ``string1`` ``string2``)`
-
+`(string.append ``string1`` ``string2``)`  
 Returns a new string consisting of the concatenation of `string1` with
-`string2`.  
- 
+`string2`.
 
-`(string-to-number ``string``)`
-
+`(string-to-number ``string``)`  
 Converts `string` into a corresponding *number* object. String is
 interpreted as decimal based integer.
 
-`(number-to-string number)`
+`(number-to-string ``number``)`  
+Converts `number` into a *string* object.
 
-Converts `number` into a *string* object.  
- 
-
-`(ascii ``number``)`
-
+`(ascii ``number``)`  
 Converts `number` into a *string* with one character, which corresponds
-to the ASCII representation of `number`.  
- 
+to the ASCII representation of `number`.
 
-`(ascii->number ``string``)`
-
+`(ascii->number ``string``)`  
 Converts the first character of `string` into a *number* which
-corresponds to its ASCII value.
-
- 
+corresponds to its ASCII value.
 
 ##### Arithmetic Operations
 
-`(+` \[`arg` ..\]`)`  
-Returns the sum of all `arg`s or `0` if none given.
+`(+` \[`arg` ..\]`)`  
+Returns the sum of all `arg`s or `0` if none given.
 
 `(*` \[`arg` ..\]`)`  
 Returns the product of all `arg`s or `1` if none given.
 
-`(-` \[`arg` ..\]`)`  
-Returns 0 if no `arg` is given, -`arg` if only one is given, `arg` minus
-the sum of all others otherwise.
+`(-` \[`arg` ..\]`)`  
+Returns 0 if no `arg` is given, -`arg` if only one is given, `arg` minus
+the sum of all others otherwise.
 
 `(/ ``arg` \[`div` ..\]`)`  
 Returns 1/`arg` if no `div` is given, `arg`/`div`\[/`div`../\] if one or
@@ -329,121 +310,117 @@ the signs of all operands is even, `-inf` if it is odd.
 `(% ``arg` \[`div` ..\]`)`  
 Returns `1` if no `div` is given, `arg`%`div`\[%`div` ..\] if one or
 more `div`s are given. If one of the divs is `0`, the program exits with
-an arithmetic exception.
+an arithmetic exception.
 
 `(= ``arg` \[`arg` ..\]`)`  
-\-  
- 
-
-`(< ``arg` \[`arg` ..\]`)`  
-\-  
- 
-
-`(> ``arg` \[`arg` ..\]`)`  
-\-  
- 
-
+`(< ``arg` \[`arg` ..\]`)`  
+`(> ``arg` \[`arg` ..\]`)`  
 `(<= ``arg` \[`arg` ..\]`)`  
-\-  
- 
-
 `(>= ``arg` \[`arg` ..\]`)`  
-These predicate functions apply the respective comparison operator
-between all `arg`s and return the respective result as `t` or `nil`.
+These predicate functions apply the respective comparison operator
+between all `arg`s and return the respective result as `t` or `nil`. If
+only one `arg` is given they all return `t`.
 
-### Editor Extensions
+### Editor Extension
+
+The editor extensions introduces several types of objects/functionality:
+
+- <span class="dfn">Buffers</span> hold text
+- <span class="dfn">Windows</span> display buffer contents to the user
+- <span class="dfn">Keyboard Input</span> allows the user to interact
+  with buffers and windows
+- The <span class="dfn">Message Line</span> gives feedback to the user
+- Several other function for operating system or user interaction
 
 #### Buffers
-
-Buffers store text and allow to manipulate it. A buffer has the
-following properties:
-
-`Name`  
-Buffers are identified by their name. If a buffer name is enclosed in
-\*asterisks\* the buffer receives special treatment.
-
-`Text`  
-0 or more characters.
-
-`Point`  
-The position in the text where text manipulation takes place.
-
-`Mark`  
-An optional second position in the text. If the `mark` is set, the text
-between `point` and `mark` is called the
-<span class="dfn">selection</span> or <span class="dfn">region</span>.
-
-`Filename`  
-A buffer can be associated with a file.
-
-`Flags`  
-Different flags determine the behaviour of the buffer.
 
 This section describes the buffer related functions added by Femto to
 fLisp. The description is separated in function related to buffer
 management and text manipulation. Buffer management creates, deletes
 buffers, or selects one of the existing buffers as the “current” buffer.
-Text manipulation always operates on the current buffer.
+Text manipulation always operates on the current buffer.
 
-Femto provides a single temporary string storage named
-<span class="dfn">clipboard</span> to support text manipulation.
+Buffers store text and allow to manipulate it. A buffer has the
+following properties:
+
+`name`  
+Buffers are identified by their name. If a buffer name is enclosed in
+\*asterisks\* the buffer receives special treatment.
+
+`text`  
+0 or more characters.
+
+`point`  
+The position in the text where text manipulation takes place.
+
+`mark`  
+An optional second position in the text. If the `mark` is set, the text
+between `point` and `mark` is called the
+<span class="dfn">selection</span> or <span class="dfn">region</span>.
+
+`filename`  
+If set the buffer is associated with the respective file.
+
+`flags`  
+Different flags determine the behaviour of the buffer.
 
 ##### Text manipulation
 
 `(insert-string ``string``)`  
-Inserts `string` at *point*. <u>S: insert</u>.
+Inserts `string` at *point*. <u>S: insert</u>.
 
-`(insert-file-contents-literally ``string`` `\[`flag`\]`)`  
-Inserts the file `string` after *point*. If `flag` is not nil the buffer
+`(insert-file-contents-literally ``string`` `\[`flag`\]`)`  
+Inserts the file `string` after *point*. If `flag` is not nil the buffer
 is marked as not modified. <u>B</u>
 
 Note: Currently the flag is forced to nil. The function should return
-`(``filename`` ``count``)` but it returns a flag indicating if the
+`(``filename`` ``count``)` but it returns a flag indicating if the
 operation succeeded.
 
 `(erase-buffer)`  
-Erases all text in the current buffer. <u>C</u>
+Erases all text in the current buffer. <u>C</u>
 
 `(delete)`  
 Deletes the character after *point*. <u>S: delete-char</u>
 
 `(backspace)`  
-Deletes the character to the left of *point*.
-<u>S: delete-backward-char</u>
+Deletes the character to the left of *point*. <u>S:
+delete-backward-char</u>
 
 `(get-char)`  
-Returns the character to the left of *point*. <u>S: get-byte</u>
+Returns the character to the left of *point*. <u>S: get-byte</u>
 
 `(copy-region)`  
-Copies *region* to the *clipboard*. <u>S: copy-region-as-kill</u>
+Copies *region* to the *clipboard*. <u>S: copy-region-as-kill</u>
 
 `(kill-region)`  
-Deletes the text in the *region* and copies it to the *clipboard*.
+Deletes the text in the *region* and copies it to the *clipboard*.
 <u>D</u>
 
 `(yank)`  
-Pastes the *clipboard* before *point*. <u>C</u>
+Pastes the *clipboard* before *point*. <u>C</u>
 
 ##### Selection
 
-(set-mark)  
+`(set-mark)`  
 Sets `mark` to `point`. <u>D</u>
 
-(get-mark)  
+`(get-mark)`  
 Returns the position of `mark`, -1 if `mark` is unset. <u>S: mark</u>
 
-(get-point)  
+`(get-point)`  
 Returns the position of `point`. <u>S: point</u>
 
-(get-point-max)  
+`(get-point-max)`  
 Returns the maximum accessible value of point in the current buffer.
 <u>S: point-max</u>
 
 `(set-clipboard ``variable``)`  
-`Sets `*`clipboard`*` to the contents of ``variable``.` <u>S: gui-set-selection</u>
+`Sets `*`clipboard`*` to the contents of ``variable``.` <u>S:
+gui-set-selection</u>
 
 `(get-clipboard)`  
-Returns the *clipboard* contents.  <u>S: gui-get-selection</u>
+Returns the *clipboard* contents. <u>S: gui-get-selection</u>
 
 ##### Cursor Movement
 
@@ -552,7 +529,7 @@ Return the name of the current buffer. Note: <u>C</u> to `buffer-name`
 in Elisp.
 
 `(add-mode-global ``string``)`  
-Sets global mode `string` for all buffers. Currently the only global
+Sets global mode `string` for all buffers. Currently the only global
 mode is <span class="kbd">undo</span>.
 
 `(find-file ``string``)`  
@@ -563,61 +540,13 @@ Saves the buffer named `string` to disk. <u>C</u>
 
 #### User Interaction
 
-`(message ``string``)`  
-Displays `string` in the message line. <u>D</u> 
-
-`(clear-message-line)`  
-Displays the empty string in the message line.
-
-`(prompt ``prompt`` ``default``)`  
-Displays `prompt` in the command line and sets `default` as initial
-value for the user respones. The user can edit the response. When
-hitting return, the final response is returned.
-
-`(show-prompt ``prompt`` ``default``)`  
-Displays `prompt` and `default` in the commandline, but does not allow
-editing. Returns `t`.
-
-`(prompt-filename ``prompt``)`  
-Displays `prompt` in the commandline and allows to enter or search for a
-file name. Returns the relative path to the selected file name or the
-response typed by the user.
-
-`(getch)`  
-Waits for a key to be pressed and returns the key as string. See also
-`get-key-name`, `get-key-funcname` and `execute-key`.
-
-(exit)  
-Exit Femto without saving modified buffers.
-
-##### Keyboard Handling
-
-`(set-key ``key-name`` ``lisp-func``)`  
-Binds key key-name to the lisp function `lisp-func`.
-
-`(get-key-name)`  
-Returns the name of the currently pressed key, eg: `c-k` for control-k.
-
-`(get-key-funcname)`  
-Return the name of the function bound to the currently pressed key.
-
-`(execute-key)`  
-Executes the function of the last bound key.
-<span class="mark">Tbd. bound or pressed?</span>
-
-`(describe-bindings)`  
-Creates a listing of all current key bindings, in a buffer named
-`*help*` and displays it in a new window. <u>C</u>
-
-`(describe-functions)`  
-Creates a listing of all functions bound to keys in a buffer named
-`*help*` and displays it in a new window.
+This section lists function related to *window* and *message line*
+manipulation, *keyboard input* and system interaction.
 
 ##### Window Handling
 
 `(delete-other-windows)`  
- Make current window the only window. <u>C</u>  
- 
+Make current window the only window. <u>C</u>
 
 `(split-window)`  
 Splits the current window. Creates a new window for the current buffer.
@@ -637,36 +566,82 @@ Updates all modified windows.
 Updates all windows by marking them modified and calling
 `update-display`.
 
+##### Message Line
+
+`(message ``string``)`  
+Displays `string` in the message line. <u>D</u>
+
+`(clear-message-line)`  
+Displays the empty string in the message line.
+
+`(prompt ``prompt`` ``default``)`  
+Displays `prompt` in the command line and sets `default` as initial
+value for the user respones. The user can edit the response. When
+hitting return, the final response is returned.
+
+`(show-prompt ``prompt`` ``default``)`  
+Displays `prompt` and `default` in the commandline, but does not allow
+editing. Returns `t`.
+
+`(prompt-filename ``prompt``)`  
+Displays `prompt` in the commandline and allows to enter or search for a
+file name. Returns the relative path to the selected file name or the
+response typed by the user.
+
+##### Keyboard Handling
+
+`(set-key ``key-name`` ``lisp-func``)`  
+Binds key key-name to the lisp function `lisp-func`.
+
+`(get-key-name)`  
+Returns the name of the currently pressed key, eg: `c-k` for control-k.
+
+`(get-key-funcname)`  
+Return the name of the function bound to the currently pressed key.
+
+`(execute-key)`  
+Executes the function of the last bound key. <span class="mark">Tbd.
+bound or pressed?</span>
+
+`(describe-bindings)`  
+Creates a listing of all current key bindings, in a buffer named
+`*help*` and displays it in a new window. <u>C</u>
+
+`(describe-functions)`  
+Creates a listing of all functions bound to keys in a buffer named
+`*help*` and displays it in a new window.
+
+`(getch)`  
+Waits for a key to be pressed and returns the key as string. See also
+`get-key-name`, `get-key-funcname` and `execute-key`.
+
 ##### Programming and System Interaction
 
-`(eval-block)`
+`(exit)`  
+Exit Femto without saving modified buffers.
 
+`(eval-block)`  
 Evaluates the `region` in the current buffer, inserts the result at
 `point` and returns it. If `mark` in the current buffer is before
-`point` `eval-block` evaluates this `region` and inserts the result at
+`point` `eval-block` evaluates this `region` and inserts the result at
 `point`. If `point` is before `mark` `eval-block` does nothing but
 returning `t`.
 
-`(system ``string``)`
-
+`(system ``string``)`  
 Executes the
 [system(1)](https://man7.org/linux/man-pages/man3/system.3.html)
 function with `string` as parameter.
 
-`(os.getenv ``string``) `
-
+`(os.getenv ``string``) `  
 Returns the value of the environment variable named `string`.
 
-`(log-message ``string``)`
+`(log-message ``string``)`  
+Logs `string` to the `*messages*` buffer.
 
-Logs `string` to the `*messages*` buffer. 
-
-`(log-debug ``string``)`
-
+`(log-debug ``string``)`  
 Logs string to the file `debug.out`.
 
-`(get-version-string)`
-
+`(get-version-string)`  
 Returns the complete version string of Femto, including the copyright.
 
 ### Implementation Details

--- a/makefile
+++ b/makefile
@@ -77,8 +77,8 @@ main.o: main.c header.h
 	  -D E_INITFILE=$(INITFILE) \
 	  -c main.c
 
-docs/flisp.md: pdoc/flisp.html
-	pandoc -o $@ -t gfm $<
+docs/flisp.md: pdoc/flisp.html pdoc/h2m.lua
+	pandoc -o $@ -t gfm -L pdoc/h2m.lua $<
 
 README.html: README.md
 	pandoc -o $@ -f gfm $<

--- a/pdoc/flisp.html
+++ b/pdoc/flisp.html
@@ -1,462 +1,601 @@
 <!DOCTYPE html>
 <html lang="en" xml:lang="en">
-<head>
-	<title>fLisp Manual</title>
-	<meta content="text/html; charset=utf-8" http-equiv="content-type" /><meta content="Emacs, editor, Lisp, tiny, reference, manual" name="keywords" /><meta content="Reference and user manual for the fLisp programming language and interpreter" name="description" /><meta content="Georg Lehner &lt;jorge@magma-soft.at&gt;" name="author" /><meta content="2023" name="copyright" />
-</head>
-<body>
-<h1>fLisp Manual</h1>
-
-<h3>Introduction</h3>
-
-<p><i>fLisp</i> is a tiny yet practical interpreter for a dialect of the Lisp programming language. It is used as extension language for the <a href="https://github.com/matp/tiny-lisp">Femto</a> text editor.</p>
-
-<p><i>fLisp</i>&nbsp;originates from <a href="https://github.com/matp/tiny-lisp">Tiny-Lisp by matp </a>(pre 2014), was integrated into <a href="https://github.com/hughbarney/femto">Femto</a> by Hugh Barnes (pre 2016) and compacted by Georg Lehner in 2023.</p>
-
-<blockquote>
-<p>A designer knows he has achieved perfection not when there is nothing left to add, but when there is nothing left to take away.</p>
-
-<p>&mdash; Antoine de Saint-Exupery</p>
-</blockquote>
-
-<h3>Lisp</h3>
-
-<h4>Notation Convention</h4>
-
-<p>fLisp fancies to converge toward Emacs Lisp. Functions descriptions are annoted with a compatibility scale:</p>
-
-<dl>
-	<dt><u>C</u></dt>
-	<dd>Interface compatible, though probably less featureful.</dd>
-	<dt><u>D</u></dt>
-	<dd>Same name, but different behavior.</dd>
-	<dt><u>S: <var>name</var></u></dt>
-	<dd><var>name</var> is a similar but not compatible function in Emacs Lisp.</dd>
-	<dt><u>B</u></dt>
-	<dd>Buggy/incompatible implementation.</dd>
-</dl>
-
-<p>Annotation is omitted if the function does not exist in Emacs Lisp.</p>
-
-<h4>fLisp Interpreter</h4>
-
-<p>When <i>fLisp</i> is invoked it follows a three step process:</p>
-
-<ol>
-	<li>Read: program text is read in and converted into an internal representation.</li>
-	<li>Evaluate: the internal representation is evaluated</li>
-	<li>Print: the result of the evaluation is returned to the invoker.</li>
-</ol>
-
-<p>Core functions of the language operate on internal objects only. The interpreter is extended with additional functions in order to interact with external objects.&nbsp; With respect to the interpreter, extension functions behave the same as core functions.</p>
-
-<h4>Syntax</h4>
-
-<p>Program text is written as a sequence of symbolic expressions - <abbr><dfn>sexp</dfn></abbr>&#39;s in parenthesized form. A sexp is either a&nbsp;single object or a function invocation enclosed in parens. Function invocations can be infinitely nested.</p>
-
-<p>The following characters are special to the reader:</p>
-
-<dl>
-	<dt><code>(</code></dt>
-	<dd>Starts a function invocation, <i>list</i> or <i>cons</i> object (see &quot;Objects and Data Types&quot;).<br />
-	&nbsp;</dd>
-	<dt><code>)</code></dt>
-	<dd>Finishes a function invocation, <i>list</i> or <i>cons</i> object.<br />
-	&nbsp;</dd>
-	<dt><code>&quot;</code></dt>
-	<dd>Encloses strings.<br />
-	&nbsp;</dd>
-	<dt><code>&#39;</code></dt>
-	<dd>With a single quote prefix before a <i>sexp</i>, the <i>sexp</i> is expanded to <code>(quote <var>sexp</var>)</code> before it is evaluated.</dd>
-	<dt><code>.</code></dt>
-	<dd>The expresion<code> (<var>a</var> . <var>b</var>)</code>&nbsp;evaluates to a <i>cons</i> object, holding the objects <var>a</var> and <var>b</var>.</dd>
-</dl>
-
-<p>Numbers are represented in decimal notation.</p>
-
-<p>A list of objects has the form:</p>
-
-<blockquote>
-<p><code><font face="monospace">(</font></code><font face="monospace">[</font><code><font face="monospace"><var>element</var></font></code><font face="monospace"> ..]</font><code><font face="monospace">)</font></code></p>
-</blockquote>
-
-<p>A function invocation has the form:</p>
-
-<blockquote>
-<p><code>(<var>name</var> </code>[<code><var>param</var> </code>..]<code>)</code></p>
-</blockquote>
-
-<p>There are two predefined objects. Their symbols are:</p>
-
-<dl>
-	<dt><code>nil</code></dt>
-	<dd>represents:&nbsp;the empty list:&nbsp;(),&nbsp;the end of a list marker or&nbsp;the false value in logical operations.<br />
-	&nbsp;</dd>
-	<dt><code>t</code></dt>
-	<dd>a fixed, non-false&nbsp;value.</dd>
-</dl>
-
-<h4>Objects and Data Types</h4>
-
-<p><i>fLisp</i> objects have exactly one of the following data types:</p>
-
-<dl>
-	<dt><dfn>number</dfn></dt>
-	<dd><a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format">double precision floating point number.</a></dd>
-	<dt><dfn>string</dfn></dt>
-	<dd>character array.</dd>
-	<dt><dfn>cons</dfn></dt>
-	<dd>object holding two pointers to objects.</dd>
-	<dt><dfn>symbol</dfn></dt>
-	<dd>string with restricted character set: <code>[A-Z][0-9][a-z]!#$%&amp;*+-./:&lt;=&gt;?@^_~</code></dd>
-	<dt><dfn>lambda</dfn></dt>
-	<dd>anonymous function with parameter evaluation</dd>
-	<dt><dfn>macro</dfn></dt>
-	<dd>anonymous function without parameter evaluation</dd>
-</dl>
-
-<p>Objects are unmutable, all fLisp functions create new objects from existing ones.</p>
-
-<p>Characters do not have their own type. A single character is represented by a <i>string</i> with length 1.</p>
-
-<h4>Symbols, Environments and Functions</h4>
-
-<p>All operations of the interpreter take place in a root environment. An <dfn>environment</dfn> is a collection of named objects. The object names have the <var>symbol</var> datatype.</p>
-
-<p><var>lambda</var> and <var>macro</var> objects are functions. They have a parameter list and a body. When they are invoked, they receive zero or more named objects, bind them one by one to the symbols in the paramter list, evaluate the body and return a result.</p>
-
-<p>When a function executed within the function body want&#39;s to use a named object it is first looked up in the new environment, and then recursively in the environments from which the <var>lambda</var>&nbsp;or <var>macro</var> was invoked.</p>
-
-<p><var>lambda</var>s evaluate each parameter then create a new environment containing the parameters before evaluating the body.</p>
-
-<p><i>macros</i> evaluate the body which typically returns a new expresions in terms of the parameters. The expression is then evaluated in a new environment containing the parameters.</p>
-
-<h4>Functions</h4>
-
-<h5>Interpreter</h5>
-
-<dl>
-	<dt><code>(progn</code> [<code><var>expr</var></code> ..]<code>)</code></dt>
-	<dd>Each <var>expr</var> is evaluated, the value of the last is returned.<br />
-	&nbsp;</dd>
-	<dt><code>(cond</code> [<code><var>clause</var></code> ..]<code>)</code></dt>
-	<dd>Each <var>clause</var> is of the form <code>(<var>pred</var> [<var>action</var>])</code>. <code>cond</code> evaluates each <var>clause</var> in turn:&nbsp;if <var>pred</var> evaluates to <code>nil</code>, the next <var>clause</var> is tested. Otherwise: if there is no <var>action</var> the value of <var>pred</var> is returned, otherwise <code>(progn <var>action</var>)</code> is returned and no more <var>clause</var>s are evaluated.</dd>
-	<dt><code>(setq <var>symbol</var> <var>value</var></code> [<code><var>symbol</var> <var>value</var></code>]..<code>)</code></dt>
-	<dd>Create or update named objects: If <var>symbol</var> is the name of an existing named object in the current or a parent environment the named object is set to <var>value</var>, if no symbol with this name exists, a new one is created in the current environment. <code>setq</code> returns the last <var>value</var>.</dd>
-	<dt><code>(lambda&nbsp;<var>params</var> <var>body</var>)</code></dt>
-	<dd>Returns a <var>lambda</var> function which accepts 0 or more arguments, which are passed as list in the parameter <var>params</var>.</dd>
-	<dt><code>(lambda (</code>[<code><var>param</var></code> ..]<code>) <var>body</var>)</code></dt>
-	<dd>Returns a <var>lambda</var> function which accepts the exact number of arguments given in the list of&nbsp;<var>param</var>s.</dd>
-	<dt><code>(lambda (<var>param</var></code> [<code><var>param</var></code> ..]<code> . opt)</code></dt>
-	<dd>Returns a <var>lambda</var> function which requires at least the exact number of arguments given in the list of <var>param</var>s. All extra arguments are passed as a list in the parameter <var>opt</var>.</dd>
-	<dt><code>(macro&nbsp;<var>params</var> <var>body</var>)</code></dt>
-	<dd>
-	<p>These forms return a <var>macro</var> function with the same parameter handling as with <var>lambda</var>.</p>
-	</dd>
-	<dt><code>(macro (</code>[<code><var>param</var></code> ..]<code>) <var>body</var>)</code></dt>
-	<dd>
-	<p>-</p>
-	</dd>
-	<dt><code>(macro (<var>param</var></code> [<code><var>param</var></code> ..]<code> . opt)</code></dt>
-	<dd>
-	<p>-</p>
-	</dd>
-	<dt><code>(quote <var>expr</var>)</code></dt>
-	<dd>quote returns <var>expr</var>&nbsp;without evaluating it.<br />
-	&nbsp;</dd>
-	<dt>(signal symbol list)</dt>
-	<dd>tbd</dd>
-	<dt>(trap list)</dt>
-	<dd>tbd</dd>
-	<dt>&nbsp;</dt>
-	<dd>&nbsp;</dd>
-</dl>
-
-<h5>Objects</h5>
-
-<dl>
-	<dt><code>(null <var>object</var>)</code></dt>
-	<dd>Returns <code>t</code> if <var>object</var>&nbsp;is&nbsp;<code>nil</code>, otherwise <code>nil</code>.</dd>
-	<dt><code>(symbolp <var>object</var>)</code><span style="display: none;">&nbsp;</span><span style="display: none;">&nbsp;</span></dt>
-	<dd>Returns <code>t</code> if <var>object</var> is of type <i>symbol,&nbsp;</i>otherwise <code>nil</code>.</dd>
-	<dt><code>(symbol-name <var>object</var>)</code></dt>
-	<dd>If <var>object</var> is of type <i>symbol</i> return its value as string.</dd>
-	<dt><code>(numberp <var>object</var>)</code></dt>
-	<dd>Returns <code>t</code> if <var>object</var> is of type <i>number</i>,&nbsp;otherwise <code>nil</code>.</dd>
-	<dt><code>(stringp <var>object</var>)</code> Returns <code>t</code> if <var>object</var> is of type <i>string</i>, otherwise <code>nil</code>.</dt>
-	<dd>&nbsp;</dd>
-	<dt><code>(consp <var>object</var>)</code></dt>
-	<dd>Returns <code>t</code> if <var>object</var> is of type <i>cons</i>, otherwise <code>nil</code>.</dd>
-	<dt><code>(cons <var>car</var> <var>cdr</var>)</code></dt>
-	<dd>Returns a new <i>cons</i> with the first object set to the value of <var>car</var> and the second to the value of <var>cdr</var>.</dd>
-	<dt><code>(car <var>cons</var>)</code></dt>
-	<dd>Returns the first object of <var>cons</var>.</dd>
-	<dt><code>(cdr <var>cons</var>)</code></dt>
-	<dd>Returns the second object of <var>cons</var>.</dd>
-	<dt><code>(eq <var>a</var> <var>b</var>)</code></dt>
-	<dd>Returns <code>t</code> if <var>a</var> and <var>b</var> evaluate to the same object, <code>nil</code> otherwise.</dd>
-	<dt><code>(print <var>object</var>)</code></dt>
-	<dd>Formats <var>object</var> into a string which can be read by the reader and returns it. As a side effect, the string is printed to the output stream with a leading and a closing newline.&nbsp;<code>print</code> escapes quotes in strings with a backslash.</dd>
-	<dt><code>(princ <var>object</var>)</code></dt>
-	<dt>Formats <var>object</var> into a string and returns it, As a side effect, the string is printed to the output stream.</dt>
-</dl>
-
-<h5>String operations</h5>
-
-<dl>
-	<dt><code>(string.length <var>string</var>)</code></dt>
-	<dd>Returns the length of <var>string</var> as a <i>number</i>.</dd>
-	<dd>&nbsp;</dd>
-	<dt><code>(string.substring <var>string</var> <var>start</var> <var>end</var>)</code></dt>
-	<dd>Returns the substring from <var>string</var> which starts with the character&nbsp;at index <var>start</var> and ends with index <var>end</var>. String indexes are zero based.</dd>
-	<dt><code>(string.append <var>string1</var> <var>string2</var>)</code></dt>
-	<dd>Returns a new string consisting of the concatenation of <var>string1</var> with <var>string2</var>.<br />
-	&nbsp;</dd>
-	<dt><code>(string-to-number <var>string</var>)</code></dt>
-	<dd>Converts <var>string</var> into a corresponding <i>number</i> object. String is interpreted as decimal based integer.</dd>
-	<dt><var><code>(number-to-string number)</code></var></dt>
-	<dd>Converts <var>number</var> into a <i>string</i> object.<br />
-	&nbsp;</dd>
-	<dt><code>(ascii <var>number</var>)</code></dt>
-	<dd>Converts <var>number</var> into a <i>string</i> with one character, which corresponds to the ASCII representation of <var>number</var>.<br />
-	&nbsp;</dd>
-	<dt><code>(ascii-&gt;number <var>string</var>)</code></dt>
-	<dd>Converts the first character of <var>string</var> into a <i>number</i> which corresponds to its&nbsp;ASCII value.</dd>
-	<dt>&nbsp;</dt>
-</dl>
-
-<h5>Arithmetic Operations</h5>
-
-<dl>
-	<dt><code>(+</code> [<code><var>arg</var></code>&nbsp;..]<code>)</code></dt>
-	<dd>Returns the sum of all <var>arg</var>s or&nbsp;<code>0</code>&nbsp;if none given.</dd>
-	<dt><code>(*</code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>Returns the product of all <var>arg</var>s or <code>1</code> if none given.</dd>
-	<dt><code>(-</code> [<code><var>arg</var></code>&nbsp;..]<code>)</code></dt>
-	<dd>Returns 0 if no <var>arg</var> is given, -<var>arg</var> if only one is given,&nbsp;<var>arg</var> minus the sum of all others&nbsp;otherwise.</dd>
-	<dt><code>(/ <var>arg</var></code> [<code><var>div</var></code> ..]<code>)</code></dt>
-	<dd>Returns 1/<var>arg</var> if no <var>div</var> is given, <var>arg</var>/<var>div</var>[/<var>div</var>../] if one or more <var>div</var>s are given, <code>inf</code> if one of the <var>div</var>s is <code>0</code> and the sum of the signs of all operands is even, <code>-inf</code> if it is odd.</dd>
-	<dt><code>(% <var>arg</var></code> [<code><var>div</var></code> ..]<code>)</code></dt>
-	<dd>Returns <code>1</code> if no <var>div</var> is given, <var>arg</var>%<var>div</var>[%<var>div</var> ..] if one or more <var>div</var>s are given. If one of the divs is <code>0</code>, the program exits with an arithmetic&nbsp;exception.</dd>
-	<dt><code>(= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>-<br />
-	&nbsp;</dd>
-	<dt><code>(&lt;&nbsp;<var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>-<br />
-	&nbsp;</dd>
-	<dt><code>(&gt;&nbsp;<var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>-<br />
-	&nbsp;</dd>
-	<dt><code>(&lt;= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>-<br />
-	&nbsp;</dd>
-	<dt><code>(&gt;= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>These predicate functions apply&nbsp;the respective comparison operator between all <var>arg</var>s and return the respective result as <code>t</code> or <code>nil</code>.</dd>
-</dl>
-
-<h3>Editor Extensions</h3>
-
-<h4>Buffers</h4>
-
-<p>Buffers store text and allow to manipulate it. A buffer has the following properties:</p>
-
-<dl>
-	<dt><var>Name</var></dt>
-	<dd>Buffers are identified by their name. If a buffer name is enclosed in *asterisks* the buffer receives special treatment.</dd>
-	<dt><var>Text</var></dt>
-	<dd>0 or more characters.</dd>
-	<dt><var>Point</var></dt>
-	<dd>The position&nbsp;in the text where text manipulation takes place.</dd>
-	<dt><var>Mark</var></dt>
-	<dd>An optional second position in the text. If the <var>mark</var> is set, the text between <var>point</var> and <var>mark</var> is called the <dfn>selection</dfn>&nbsp;or <dfn>region</dfn>.</dd>
-	<dt><var>Filename</var></dt>
-	<dd>A buffer can be associated with a file.</dd>
-	<dt><var>Flags</var></dt>
-	<dd>Different flags determine the behaviour of the buffer.</dd>
-</dl>
-
-<p>This section describes the buffer related functions added by Femto to fLisp. The description is separated in function related to buffer management and text manipulation. Buffer management creates, deletes buffers, or selects one of the existing buffers as the <q>current</q> buffer. Text manipulation always operates on the&nbsp;current buffer.</p>
-
-<p>Femto provides a single temporary string storage named <dfn>clipboard</dfn>&nbsp;to support text manipulation.</p>
-
-<h5>Text manipulation</h5>
-
-<dl>
-	<dt><code>(insert-string <var>string</var>)</code></dt>
-	<dd>Inserts&nbsp;<var>string</var> at <i>point</i>. <u>S: insert</u>.</dd>
-	<dt><code>(insert-file-contents-literally <var>string</var>&nbsp;</code>[<code><var>flag</var></code>]<code>)</code></dt>
-	<dd>
-	<p>Inserts the file <var>string</var>&nbsp;after&nbsp;<i>point</i>. If <var>flag</var> is not nil the buffer is marked as not modified. <u>B</u></p>
-	</dd>
-	<dd>
-	<p>Note: Currently the flag is forced to nil. The function should return <code>(<var>filename</var> <var>count</var>)</code>&nbsp;but it returns a flag indicating if the operation succeeded.</p>
-	</dd>
-	<dt><code>(erase-buffer)</code></dt>
-	<dd>Erases all text in&nbsp;the current buffer. <u>C</u></dd>
-	<dt><code>(delete)</code></dt>
-	<dd>Deletes the character after <i>point</i>. <u>S: delete-char</u></dd>
-	<dt><code>(backspace)</code></dt>
-	<dd>Deletes the character to the left of <i>point</i>. <u>S:&nbsp;delete-backward-char</u></dd>
-	<dt><code>(get-char)</code></dt>
-	<dd>Returns the character to the left of <i>point</i>. <u>S:&nbsp;get-byte</u></dd>
-	<dt><code>(copy-region)</code></dt>
-	<dd>Copies&nbsp;<i>region</i> to&nbsp;the <i>clipboard</i>. <u>S:&nbsp;copy-region-as-kill</u></dd>
-	<dt><code>(kill-region)</code></dt>
-	<dd>Deletes the text in&nbsp;the <i>region</i> and copies&nbsp;it to the <i>clipboard</i>. <u>D</u></dd>
-	<dt><code>(yank)</code></dt>
-	<dd>Pastes the <i>clipboard</i>&nbsp;before <i>point</i>. <u>C</u></dd>
-</dl>
-
-<h5>Selection</h5>
-
-<dl>
-	<dt>(set-mark)</dt>
-	<dd>Sets <var>mark</var> to <var>point</var>. <u>D</u></dd>
-	<dt>(get-mark)</dt>
-	<dd>Returns the position of <var>mark</var>, -1 if <var>mark</var> is unset. <u>S: mark</u></dd>
-	<dt>(get-point)</dt>
-	<dd>Returns the position of <var>point</var>. <u>S: point</u></dd>
-	<dt>(get-point-max)</dt>
-	<dd>Returns the maximum accessible value of point in the current buffer. <u>S: point-max</u></dd>
-	<dt><code>(set-clipboard <var>variable</var>)</code></dt>
-	<dd><code>Sets <i>clipboard</i> to the contents of <var>variable</var>.</code>&nbsp;<u>S:&nbsp;gui-set-selection</u></dd>
-	<dt><code>(get-clipboard)</code></dt>
-	<dd>Returns the <i>clipboard</i> contents.&nbsp;&nbsp;<u>S:&nbsp;gui-get-selection</u></dd>
-</dl>
-
-<h5>Cursor Movement</h5>
-
-<dl>
-	<dt><code>(set-point <var>number</var>)</code></dt>
-	<dd>Sets the point to in the current buffer to the position <var>number</var>. <u>S: goto-char</u></dd>
-	<dt><code>(goto-line <var>number</var>)</code></dt>
-	<dd>Sets the point in the current buffer to the first character on line <var>number</var>. <u>S: goto-line</u>, not an Elisp function.</dd>
-	<dt><code>(search-forward <var>string</var>)</code></dt>
-	<dd>Searches for <var>string</var> in the current buffer, starting from point forward. If string is found, sets the point after the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone and returns <samp>nil</samp>. <u>D</u></dd>
-	<dt><code>(search-backward <var>string</var>)</code></dt>
-	<dd>Searches for <var>string</var> in the current buffer, starting from point backwards. If string is found, sets the point before the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone and returns <samp>nil</samp>. <u>D</u></dd>
-	<dt><code>(beginning-of-buffer)</code></dt>
-	<dd>Sets the point in the current buffer to the first buffer position, leaving mark in its current position. <u>C</u></dd>
-	<dt><code>(end-of-buffer)</code></dt>
-	<dd>Sets the point in the current buffer to the last buffer position, leaving mark in its current position. <u>C</u></dd>
-	<dt><code>(beginning-of-line)</code></dt>
-	<dd>Sets point before the first character of the current line, leaving mark in its current position. <u>S: move-beginning-of-line</u></dd>
-	<dt><code>(end-of-line)</code></dt>
-	<dd>Sets point after the last character of the current line, i.e. before the end-of-line character sequence, leaving mark in its current position. <u>S: move-end-of-line</u></dd>
-	<dt><code>(forward-word)</code></dt>
-	<dd>Moves the point in the current buffer forward before the first char of the next word. If there is no word left the point is set to the end of the buffer. If the point is already at the start or within a word, the current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>end</em> of the the next word.</dd>
-	<dt><code>(backward-word)</code></dt>
-	<dd>Moves the point in the current buffer backward after the last char of the previous word. If there is no word left the point is set to the beginning of the buffer. If the point is already at the end or within a word, the current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>beginning</em> of the previous word.</dd>
-	<dt><code>(forward-char)</code></dt>
-	<dd>Moves the point in the current buffer one character forward, but not past the end of the buffer. <u>C</u></dd>
-	<dt><code>(backward-char)</code></dt>
-	<dd>Moves the point in the current buffer one character backward, but not before the end of the buffer. <u>C</u></dd>
-	<dt><code>(forward-page)</code></dt>
-	<dd>Moves the point of the current buffer to the beginning of the last visible line of the associated screen and scrolls the screen up to show it as the first line. <u>S: scroll-up</u></dd>
-	<dt><code>(backward-page)</code></dt>
-	<dd>Moves the point of the current buffer to the beginning of the first visible line of the associoated screen and scrolls the screen down to show it as the last line. <u>S: scroll-down</u></dd>
-	<dt><code>(next-line)</code></dt>
-	<dd>Moves the point in the current buffer to the same character position in the next line, or to the end of the next line if there are not enough characters. In the last line of the buffer moves the point to the end of the buffer. <u>C</u></dd>
-	<dt><code>(previous-line)</code></dt>
-	<dd>Movest the point in the current buffer to the same character position in the previous line, or to the end of the previous line if there are not enough characters. In the first line of the buffer the point is not moved. <u>C</u></dd>
-</dl>
-
-<h5>Buffer management</h5>
-
-<dl>
-	<dt><code>(list-buffers)</code></dt>
-	<dd>Lists all the buffers in a buffer called <samp>*buffers*</samp>.</dd>
-	<dt><code>(get-buffer-count)</code></dt>
-	<dd>Returns the number of buffers, includes all special buffers and <samp>*buffers*</samp>.</dd>
-	<dt><code>(select-buffer <var>string</var>)</code></dt>
-	<dd>Makes the buffer named <var>string</var> the current buffer. Note: <u>C</u> to <code>set-buffer</code> in Elisp.</dd>
-	<dt><code>(rename-buffer <var>string</var>)</code></dt>
-	<dd>Rename the current buffer to <var>string</var>. <u>C</u></dd>
-	<dt><code>(kill-buffer <var>string</var>)</code></dt>
-	<dd>Kill the buffer names <var>string</var>. Unsaved changes are discarded. <u>C</u></dd>
-	<dt><code>(get-buffer-name)</code></dt>
-	<dd>Return the name of the current buffer. Note: <u>C</u> to <code>buffer-name</code> in Elisp.</dd>
-	<dt><code>(add-mode-global <var>string</var>)</code></dt>
-	<dd>Sets global mode&nbsp;<var>string</var> for all buffers. Currently the only global mode is <kbd>undo</kbd>.</dd>
-	<dt><code>(find-file <var>string</var>)</code></dt>
-	<dd>Loads file with path string into a new buffer. <u>C</u></dd>
-	<dt><code>(save-buffer <var>string</var>)</code></dt>
-	<dd>Saves the buffer named <var>string</var> to disk. <u>C</u></dd>
-</dl>
-
-<h4>User Interaction</h4>
-
-<dl>
-	<dt><code>(message <var>string</var>)</code></dt>
-	<dd>Displays&nbsp;<var>string</var> in the message line. <u>D</u>&nbsp;</dd>
-	<dt><code>(clear-message-line)</code></dt>
-	<dd>Displays the empty string in the message line.</dd>
-	<dt><code>(prompt <var>prompt</var> <var>default</var>)</code></dt>
-	<dd>Displays&nbsp;<var>prompt</var> in the command line and sets <var>default</var> as initial value for the user respones. The user can edit the response. When hitting return, the final response is returned.</dd>
-	<dt><code>(show-prompt <var>prompt</var> <var>default</var>)</code></dt>
-	<dd>Displays <var>prompt</var> and <var>default</var> in the commandline, but does not allow editing. Returns <samp>t</samp>.</dd>
-	<dt><code>(prompt-filename <var>prompt</var>)</code></dt>
-	<dd>Displays <var>prompt</var> in the commandline and allows to enter or search for a file name. Returns the relative path to the selected file name or the response typed by the user.</dd>
-	<dt><code>(getch)</code></dt>
-	<dd>Waits for a key to be pressed and returns the key as string. See also <code>get-key-name</code>, <code>get-key-funcname</code> and <code>execute-key</code>.</dd>
-	<dt>(exit)</dt>
-	<dd>Exit Femto without saving modified buffers.</dd>
-</dl>
-
-<h5>Keyboard Handling</h5>
-
-<dl>
-	<dt><code>(set-key <var>key-name</var> <var>lisp-func</var>)</code></dt>
-	<dd>Binds key key-name to the lisp function <var>lisp-func</var>.</dd>
-	<dt><code>(get-key-name)</code></dt>
-	<dd>Returns the name of the currently pressed key, eg: <samp>c-k</samp> for control-k.</dd>
-	<dt><code>(get-key-funcname)</code></dt>
-	<dd>Return the name of the function bound to the currently pressed key.</dd>
-	<dt><code>(execute-key)</code></dt>
-	<dd>Executes the function of the last bound key. <mark>Tbd.&nbsp;bound or pressed?</mark></dd>
-	<dt><code>(describe-bindings)</code></dt>
-	<dd>Creates a listing of all current key bindings, in a buffer named <samp>*help*</samp> and displays it in a new window. <u>C</u></dd>
-	<dt><code>(describe-functions)</code></dt>
-	<dd>Creates a listing of all functions bound to keys in a buffer named <samp>*help*</samp> and displays it in a new window.</dd>
-</dl>
-
-<h5>Window Handling</h5>
-
-<dl>
-	<dt><code>(delete-other-windows)</code></dt>
-	<dt>&nbsp;Make current window the only window. <u>C</u></dt>
-	<dd>&nbsp;</dd>
-	<dt><code>(split-window)</code></dt>
-	<dd>Splits the current window. Creates a new window for the current buffer. <u>C</u></dd>
-	<dt><code>(other-window)</code></dt>
-	<dd>Moves the cursor to the next window down on the screen. Makes the buffer in that window the current buffer. <u>D</u></dd>
-	<dd>Note: Elisp <code>other-window</code> has a required parameter <var>count</var>, which specifies the number of windows to move down or up.</dd>
-	<dt><code>(update-display)</code></dt>
-	<dd>Updates all modified windows.</dd>
-	<dt><code>(refresh)</code></dt>
-	<dd>Updates all windows by marking them modified and calling <code>update-display</code>.</dd>
-</dl>
-
-<h5>Programming and System Interaction</h5>
-
-<dl>
-	<dt><code>(eval-block)</code></dt>
-	<dd>Evaluates the <var>region</var> in the current buffer, inserts the result at <var>point</var> and returns it. If <var>mark</var> in the current buffer is before <var>point</var> <code>eval-block</code> evaluates this <var>region</var>&nbsp;and inserts the result at <var>point</var>. If <var>point</var> is before <var>mark</var> <code>eval-block</code> does nothing but returning <samp>t</samp>.</dd>
-	<dt><code>(system <var>string</var>)</code></dt>
-	<dd>Executes the <a href="https://man7.org/linux/man-pages/man3/system.3.html">system(1)</a> function with <var>string</var> as parameter.</dd>
-	<dt><code>(os.getenv <var>string</var>) </code></dt>
-	<dd>Returns the value of the environment variable named <var>string</var>.</dd>
-	<dt><code>(log-message <var>string</var>)</code></dt>
-	<dd>Logs <var>string</var> to the <samp>*messages*</samp> buffer.&nbsp;</dd>
-	<dt><code>(log-debug <var>string</var>)</code></dt>
-	<dd>Logs string to the file <code>debug.out</code>.</dd>
-	<dt><code>(get-version-string)</code></dt>
-	<dd>Returns the complete version string of Femto, including the copyright.</dd>
-	<dt>
-	<h3>Implementation Details</h3>
-
-	<p><mark>Tbd.: Memory consumption, limits, hacking, ...</mark></p>
-	</dt>
-</dl>
-</body>
+  <head>
+    <title>fLisp Manual</title>
+    <meta content="text/html; charset=utf-8" http-equiv="content-type" />
+    <meta content="Emacs, editor, Lisp, tiny, reference, manual" name="keywords" />
+    <meta content="Reference and user manual for the fLisp programming language and interpreter" name="description" />
+    <meta content="Georg Lehner &lt;jorge@magma-soft.at&gt;" name="author" />
+    <meta content="2023" name="copyright" />
+  </head>
+  <body>
+    <h1>fLisp Manual</h1>
+
+    <h3>Introduction</h3>
+    <blockquote>
+      <p>
+	A designer knows he has achieved perfection not when there is nothing left to add, but when there is nothing
+	left to take away.
+      </p>
+
+      <p>&mdash; Antoine de Saint-Exupery</p>
+    </blockquote>
+    <p>
+      <i>fLisp</i> is a tiny yet practical interpreter for a dialect of the Lisp programming language. It is used as
+      extension language for the <a href="https://github.com/matp/tiny-lisp">Femto</a> text editor.
+    </p>
+    <p>
+      <i>fLisp</i> originates from <a href="https://github.com/matp/tiny-lisp">Tiny-Lisp by matp </a>(pre 2014), was
+    integrated into <a href="https://github.com/hughbarney/femto">Femto</a> by Hugh Barnes (pre 2016) and compacted by
+    Georg Lehner in 2023.
+    </p>
+    <p>This is a reference manual. If you want to learn about Lisp programming use other resources eg.</p>
+    <ul>
+      <li>The <a href="lisp-lang.org">Common Lisp</a> web site,</li>
+      <li>
+	<a href="https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html">An Introduction to Programming in
+	  Emacs Lisp</a> or
+      </li>
+      <li><a href="https://www.scheme.org/">The Scheme Programming Language</a>.</li>
+    </ul>
+    <h3>Lisp</h3>
+    <h4>Notation Convention</h4>
+
+    <p>
+      <i>fLisp</i> fancies to converge toward Emacs Lisp. Function descriptions are annoted with a compatibility
+      scale:
+    </p>
+    <dl>
+      <dt><u>C</u></dt>
+      <dd>Interface compatible, though probably less featureful.</dd>
+      <dt><u>D</u></dt>
+      <dd>Same name, but different behavior.</dd>
+      <dt><u>S: <var>name</var></u></dt>
+      <dd><var>name</var> is a similar but not compatible function in Emacs Lisp.</dd>
+      <dt><u>B</u></dt>
+      <dd>Buggy/incompatible implementation.</dd>
+    </dl>
+    <p>Annotation is omitted if the function does not exist in Emacs Lisp.</p>
+
+    <h4>fLisp Interpreter</h4>
+
+    <p>When <i>fLisp</i> is invoked it follows a three step process:</p>
+    <ol>
+      <li>Read: program text is read in and converted into an internal representation.</li>
+      <li>Evaluate: the internal representation is evaluated</li>
+      <li>Print: the result of the evaluation is returned to the invoker.</li>
+    </ol>
+    <p>
+      Core functions of the language operate on built-in objects only. <i>fLisp</i> is extended with additional
+      functions in order to interact with editor related objects. With respect to the interpreter, extension functions
+      behave the same as core functions.
+    </p>
+
+    <h4>Syntax</h4>
+
+    <p>
+      Program text is written as a sequence of symbolic expressions - <abbr><dfn>sexp</dfn></abbr>&#39;s - in
+      parenthesized form. A sexp is either a single object or a function invocation enclosed in parens. Function
+      invocations can be infinitely nested.
+    </p>
+    <p>The following characters are special to the reader:</p>
+    <dl>
+      <dt><code>(</code></dt>
+      <dd>Starts a function invocation, <i>list</i> or <i>cons</i> object (see <a href="#objects_and_data_types">Objects
+      and Data Types</a>).</dd>
+      <dt><code>)</code></dt>
+      <dd>Finishes a function invocation, <i>list</i> or <i>cons</i> object</dd>
+      <dt><code>&quot;</code></dt>
+      <dd>Encloses strings.</dd>
+      <dt><code>&#39;</code></dt>
+      <dd>With a single quote prefix before a <abbr>sexp</abbr>, the <abbr>sexp</abbr> is expanded
+      to <code>(quote <var>sexp</var>)</code> before it is evaluated.</dd>
+      <dt><code>.</code></dt>
+      <dd>The expresion<code> (<var>a</var> . <var>b</var>)</code> evaluates to a <i>cons</i> object, holding the
+      objects <var>a</var> and <var>b</var>.</dd>
+    </dl>
+    <p>Numbers are represented in decimal notation.</p>
+    <p>A list of objects has the form:</p>
+    <blockquote>
+      <code>(</code>[<code><var>element</var></code>..]<code>)</code>
+    </blockquote>
+    <p>A function invocation has the form:</p>
+    <blockquote>
+      <code>(<var>name</var> </code>[<code><var>param</var> </code>..]<code>)</code>
+    </blockquote>
+    <p>There are two predefined objects. Their symbols are:</p>
+    <dl>
+      <dt><code>nil</code></dt>
+      <dd>
+	represents: the empty list: <code>()</code>, the end of a list marker or the false value in logical operations.
+      </dd>
+      <dt><code>t</code></dt>
+      <dd><q>true</q>, a fixed, non-false value.</dd>
+    </dl>
+
+    <h4 id="objects_and_data_types">Objects and Data Types</h4>
+
+    <p><i>fLisp</i> objects have exactly one of the following data types:</p>
+    <dl>
+      <dt><dfn>number</dfn></dt>
+      <dd>
+	<a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format">double precision floating point
+	  number.</a>
+      </dd>
+      <dt><dfn>string</dfn></dt>
+      <dd>character array.</dd>
+      <dt><dfn>cons</dfn></dt>
+      <dd>object holding two pointers to objects.</dd>
+      <dt><dfn>symbol</dfn></dt>
+      <dd>string with restricted character set: <code>[A-Z][0-9][a-z]!#$%&amp;*+-./:&lt;=&gt;?@^_~</code></dd>
+      <dt><dfn>lambda</dfn></dt>
+      <dd>anonymous function with parameter evaluation</dd>
+      <dt><dfn>macro</dfn></dt>
+      <dd>anonymous function without parameter evaluation</dd>
+    </dl>
+    <p>
+      Objects are unmutable, all <i>fLisp</i> functions create new objects from existing ones or return existing ones.
+    </p>
+    <p>Characters do not have their own type. A single character is represented by a <i>string</i> with length 1.</p>
+
+    <h4>Environments, Functions, Evaluation</h4>
+
+    <p>
+      All operations of the interpreter take place in an environment. An <dfn>environment</dfn> is a collection of named
+      objects. The object names have the <var>symbol</var> datatype.  An object in an environment is said to
+      be <dfn>bound</dfn> to its name. Environments can have a parent.  Each <i>fLisp</i> interpreter starts with
+      a <dfn>root</dfn> environment without a parent.
+    </p>
+    <p>
+      <i>lambda</i> and <i>macro</i> objects are functions. They have a parameter list and a <i>sexp</i> as body. When
+      functions are invoked a new environment is created as child of the current environment.
+    </p>
+    <p>
+      Functions receive zero or more objects from the caller.  These are bound one by one to the symbols in the
+      parameter list in the new environment.
+    </p>
+    <p><i>lambda</i>s return the result of evaluating the body in the new environment.</p>
+    <p>
+      <i>macro</i>s first evaluate the body in the calling environment. The resulting <i>sexp</i> is evaluated in the
+      new environment and that result is returned.
+    </p>
+    <p>
+      <i>macro</i> bodies typically are crafted to return new <i>sexp</i>s in terms of the parameters.
+    </p>
+    <p>
+      When a <i>sexp</i> is evaluated and encounters a <i>symbol</i> it looks it up in the current environment, and
+      then recursively in the environments from which the <var>lambda</var> or <var>macro</var> was invoked.  The symbol
+      of the first binding is then replaced by its object.
+    </p>
+    <p>
+      <i>fLisp</i> counts with a set of built-in functions called <dfn>primitives</dfn>. They are grouped in the manual
+      by the type of objects they operate on.
+    </p>
+
+    <h4>Primitives</h4>
+
+    <h5>Interpreter Operations</h5>
+
+    <dl>
+      <dt><code>(progn</code> [<code><var>expr</var></code> ..]<code>)</code></dt>
+      <dd>Each <var>expr</var> is evaluated, the value of the last is returned.
+      </dd>
+      <dt><code>(cond</code> [<code><var>clause</var></code> ..]<code>)</code></dt>
+      <dd>
+	Each <var>clause</var> is of the form <code>(<var>pred</var> [<var>action</var>])</code>. <code>cond</code>
+	evaluates each <var>clause</var> in turn: if <var>pred</var> evaluates to <code>nil</code>, the
+	next <var>clause</var> is tested. Otherwise: if there is no <var>action</var> the value of <var>pred</var> is
+	returned, otherwise <code>(progn <var>action</var>)</code> is returned and no more <var>clause</var>s are
+	evaluated.
+      </dd>
+      <dt><code>(setq <var>symbol</var> <var>value</var></code> [<code><var>symbol</var> <var>value</var></code>]..<code>)</code></dt>
+      <dd>
+	Create or update named objects: If <var>symbol</var> is the name of an existing named object in the current or a
+	parent environment the named object is set to <var>value</var>, if no symbol with this name exists, a new one is
+	created in the current environment. <code>setq</code> returns the last <var>value</var>.
+      </dd>
+      <dt><code>(lambda <var>params</var> <var>body</var>)</code></dt>
+      <dd>
+	Returns a <var>lambda</var> function which accepts 0 or more arguments, which are passed as list in the
+	parameter <var>params</var>.
+      </dd> 
+      <dt><code>(lambda (</code>[<code><var>param</var></code> ..]<code>) <var>body</var>)</code></dt>
+      <dd>
+	Returns a <var>lambda</var> function which accepts the exact number of arguments given in the list
+	of <var>param</var>s.
+      </dd>
+      <dt><code>(lambda (<var>param</var></code> [<code><var>param</var></code> ..]<code> . <var>opt</var>) <var>body</var>)</code></dt>
+      <dd>
+	Returns a <var>lambda</var> function which requires at least the exact number of arguments given in the list
+	of <var>param</var>s. All extra arguments are passed as a list in the parameter <var>opt</var>.
+      </dd>
+      <dt><code>(macro <var>params</var> <var>body</var>)</code></dt>
+      <dt><code>(macro (</code>[<code><var>param</var></code> ..]<code>) <var>body</var>)</code></dt>
+      <dt><code>(macro (<var>param</var></code> [<code><var>param</var></code> ..]<code> . <var>opt</var>) <var>body</var>)</code></dt>
+      <dd>
+	These forms return a <var>macro</var> function. Parameter handling is the same as with <var>lambda</var>.
+      </dd>
+      <dt><code>(quote <var>expr</var>)</code></dt>
+      <dd>quote returns <var>expr</var> without evaluating it.
+      </dd>
+      <dt><code>(signal <var>symbol</var> <var>list</var>)</code></dt>
+      <dd>tbd</dd>
+      <dt><code>(trap <var>list</var>)</code></dt>
+      <dd>tbd</dd>
+    </dl>
+
+    <h5>Object Operations</h5>
+
+    <dl>
+      <dt><code>(null <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is <code>nil</code>, otherwise <code>nil</code>.</dd>
+      <dt><code>(symbolp <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is of type <i>symbol, </i>otherwise <code>nil</code>.</dd>
+      <dt><code>(symbol-name <var>object</var>)</code></dt>
+      <dd>If <var>object</var> is of type <i>symbol</i> return its value as string.</dd>
+      <dt><code>(numberp <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is of type <i>number</i>, otherwise <code>nil</code>.</dd>
+      <dt><code>(stringp <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is of type <i>string</i>, otherwise <code>nil</code>.</dd>
+      <dt><code>(consp <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is of type <i>cons</i>, otherwise <code>nil</code>.</dd>
+      <dt><code>(cons <var>car</var> <var>cdr</var>)</code></dt>
+      <dd>Returns a new <i>cons</i> with the first object set to the value of <var>car</var> and the second to the value of <var>cdr</var>.</dd>
+      <dt><code>(car <var>cons</var>)</code></dt>
+      <dd>Returns the first object of <var>cons</var>.</dd>
+      <dt><code>(cdr <var>cons</var>)</code></dt>
+      <dd>Returns the second object of <var>cons</var>.</dd>
+      <dt><code>(eq <var>a</var> <var>b</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>a</var> and <var>b</var> evaluate to the same object, <code>nil</code> otherwise.</dd>
+      <dt><code>(print <var>object</var>)</code></dt>
+      <dd>
+	Formats <var>object</var> into a string which can be read by the reader and returns it. As a side effect, the
+	string is printed to the output stream with a leading and a closing newline. <code>print</code> escapes quotes
+	in strings with a backslash.
+      </dd>
+      <dt><code>(princ <var>object</var>)</code></dt>
+      <dd>
+	Formats <var>object</var> into a string and returns it, As a side effect, the string is printed to the output
+	stream.
+      </dd>
+    </dl>
+
+    <h5>String Operations</h5>
+
+    <dl>
+      <dt><code>(string.length <var>string</var>)</code></dt>
+      <dd>Returns the length of <var>string</var> as a <i>number</i>.</dd>
+      <dt><code>(string.substring <var>string</var> <var>start</var> <var>end</var>)</code></dt>
+      <dd>
+	Returns the substring from <var>string</var> which starts with the character at index <var>start</var> and ends
+	with index <var>end</var>. String indexes are zero based.
+      </dd>
+      <dt><code>(string.append <var>string1</var> <var>string2</var>)</code></dt>
+      <dd>Returns a new string consisting of the concatenation of <var>string1</var> with <var>string2</var>.</dd>
+      <dt><code>(string-to-number <var>string</var>)</code></dt>
+      <dd>
+	Converts <var>string</var> into a corresponding <i>number</i> object. String is interpreted as decimal based
+	integer.
+      </dd>
+      <dt><code>(number-to-string <var>number</var>)</code></dt>
+      <dd>Converts <var>number</var> into a <i>string</i> object.
+      </dd>
+      <dt><code>(ascii <var>number</var>)</code></dt>
+      <dd>
+	Converts <var>number</var> into a <i>string</i> with one character, which corresponds to the ASCII
+	representation of <var>number</var>.
+      </dd>
+      <dt><code>(ascii-&gt;number <var>string</var>)</code></dt>
+      <dd>
+	Converts the first character of <var>string</var> into a <i>number</i> which corresponds to its ASCII
+	value.
+      </dd>
+    </dl>
+
+    <h5>Arithmetic Operations</h5>
+
+    <dl>
+      <dt><code>(+</code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dd>Returns the sum of all <var>arg</var>s or <code>0</code> if none given.</dd>
+      <dt><code>(*</code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dd>Returns the product of all <var>arg</var>s or <code>1</code> if none given.</dd>
+      <dt><code>(-</code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dd>
+	Returns 0 if no <var>arg</var> is given, -<var>arg</var> if only one is given, <var>arg</var> minus the sum of
+	all others otherwise.
+      </dd>
+      <dt><code>(/ <var>arg</var></code> [<code><var>div</var></code> ..]<code>)</code></dt>
+      <dd>
+	Returns 1/<var>arg</var> if no <var>div</var> is given, <var>arg</var>/<var>div</var>[/<var>div</var>../] if one
+	or more <var>div</var>s are given, <code>inf</code> if one of the <var>div</var>s is <code>0</code> and the sum
+	of the signs of all operands is even, <code>-inf</code> if it is odd.
+      </dd>
+      <dt><code>(% <var>arg</var></code> [<code><var>div</var></code> ..]<code>)</code></dt>
+      <dd>
+	Returns <code>1</code> if no <var>div</var> is given, <var>arg</var>%<var>div</var>[%<var>div</var> ..] if one
+	or more <var>div</var>s are given. If one of the divs is <code>0</code>, the program exits with an arithmetic
+	exception.
+      </dd>
+      <dt><code>(= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dt><code>(&lt; <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dt><code>(&gt; <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dt><code>(&lt;= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dt><code>(&gt;= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dd>
+	These predicate functions apply the respective comparison operator between all <var>arg</var>s and return the
+	respective result as <code>t</code> or <code>nil</code>.  If only one <var>arg</var> is given they all
+	return <code>t</code>.
+      </dd>
+    </dl>
+
+    <h3>Editor Extension</h3>
+
+    <p>The editor extensions introduces several types of objects/functionality:</p>
+    <ul>
+      <li><dfn>Buffers</dfn> hold text</li>
+      <li><dfn>Windows</dfn> display buffer contents to the user</li>
+      <li><dfn>Keyboard Input</dfn> allows the user to interact with buffers and windows</li>
+      <li>The <dfn>Message Line</dfn> gives feedback to the user</li>
+      <li>Several other function for operating system or user interaction</li>
+    </ul>
+
+    <h4>Buffers</h4>
+
+    <p>
+      This section describes the buffer related functions added by Femto to fLisp. The description is separated in
+      function related to buffer management and text manipulation. Buffer management creates, deletes buffers, or
+      selects one of the existing buffers as the <q>current</q> buffer. Text manipulation always operates on the current
+      buffer.
+    </p>
+
+    <p>Buffers store text and allow to manipulate it. A buffer has the following properties:</p>
+    <dl>
+      <dt><var>name</var></dt>
+      <dd>
+	Buffers are identified by their name. If a buffer name is enclosed in *asterisks* the buffer receives special
+	treatment.
+      </dd>
+      <dt><var>text</var></dt>
+      <dd>0 or more characters.</dd>
+      <dt><var>point</var></dt>
+      <dd>The position in the text where text manipulation takes place.</dd>
+      <dt><var>mark</var></dt>
+      <dd>
+	An optional second position in the text. If the <var>mark</var> is set, the text between <var>point</var>
+	and <var>mark</var> is called the <dfn>selection</dfn> or <dfn>region</dfn>.
+      </dd>
+      <dt><var>filename</var></dt>
+      <dd>If set the buffer is associated with the respective file.</dd>
+      <dt><var>flags</var></dt>
+      <dd>Different flags determine the behaviour of the buffer.</dd>
+    </dl>
+
+    <h5>Text manipulation</h5>
+
+    <dl>
+      <dt><code>(insert-string <var>string</var>)</code></dt>
+      <dd>Inserts <var>string</var> at <i>point</i>. <u>S: insert</u>.</dd>
+      <dt><code>(insert-file-contents-literally <var>string</var> </code>[<code><var>flag</var></code>]<code>)</code></dt>
+      <dd>
+	Inserts the file <var>string</var> after <i>point</i>. If <var>flag</var> is not nil the buffer is marked as not
+	modified. <u>B</u>
+      </dd>
+      <dd>
+	<p>
+	  Note: Currently the flag is forced to nil. The function should
+	  return <code>(<var>filename</var> <var>count</var>)</code> but it returns a flag indicating if the operation
+	  succeeded.
+	</p>
+      </dd>
+      <dt><code>(erase-buffer)</code></dt>
+      <dd>Erases all text in the current buffer. <u>C</u></dd>
+      <dt><code>(delete)</code></dt>
+      <dd>Deletes the character after <i>point</i>. <u>S: delete-char</u></dd>
+      <dt><code>(backspace)</code></dt>
+      <dd>Deletes the character to the left of <i>point</i>. <u>S: delete-backward-char</u></dd>
+      <dt><code>(get-char)</code></dt>
+      <dd>Returns the character to the left of <i>point</i>. <u>S: get-byte</u></dd>
+      <dt><code>(copy-region)</code></dt>
+      <dd>Copies <i>region</i> to the <i>clipboard</i>. <u>S: copy-region-as-kill</u></dd>
+      <dt><code>(kill-region)</code></dt>
+      <dd>Deletes the text in the <i>region</i> and copies it to the <i>clipboard</i>. <u>D</u></dd>
+      <dt><code>(yank)</code></dt>
+      <dd>Pastes the <i>clipboard</i> before <i>point</i>. <u>C</u></dd>
+    </dl>
+
+    <h5>Selection</h5>
+
+    <dl>
+      <dt><code>(set-mark)</code></dt>
+      <dd>Sets <var>mark</var> to <var>point</var>. <u>D</u></dd>
+      <dt><code>(get-mark)</code></dt>
+      <dd>Returns the position of <var>mark</var>, -1 if <var>mark</var> is unset. <u>S: mark</u></dd>
+      <dt><code>(get-point)</code></dt>
+      <dd>Returns the position of <var>point</var>. <u>S: point</u></dd>
+      <dt><code>(get-point-max)</code></dt>
+      <dd>Returns the maximum accessible value of point in the current buffer. <u>S: point-max</u></dd>
+      <dt><code>(set-clipboard <var>variable</var>)</code></dt>
+      <dd><code>Sets <i>clipboard</i> to the contents of <var>variable</var>.</code> <u>S: gui-set-selection</u></dd>
+      <dt><code>(get-clipboard)</code></dt>
+      <dd>Returns the <i>clipboard</i> contents.  <u>S: gui-get-selection</u></dd>
+    </dl>
+
+    <h5>Cursor Movement</h5>
+
+    <dl>
+      <dt><code>(set-point <var>number</var>)</code></dt>
+      <dd>Sets the point to in the current buffer to the position <var>number</var>. <u>S: goto-char</u></dd>
+      <dt><code>(goto-line <var>number</var>)</code></dt>
+      <dd>Sets the point in the current buffer to the first character on line <var>number</var>. <u>S: goto-line</u>, not an Elisp function.</dd>
+      <dt><code>(search-forward <var>string</var>)</code></dt>
+      <dd>Searches for <var>string</var> in the current buffer, starting from point forward. If string is found, sets the point after the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone and returns <samp>nil</samp>. <u>D</u></dd>
+      <dt><code>(search-backward <var>string</var>)</code></dt>
+      <dd>Searches for <var>string</var> in the current buffer, starting from point backwards. If string is found, sets the point before the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone and returns <samp>nil</samp>. <u>D</u></dd>
+      <dt><code>(beginning-of-buffer)</code></dt>
+      <dd>Sets the point in the current buffer to the first buffer position, leaving mark in its current position. <u>C</u></dd>
+      <dt><code>(end-of-buffer)</code></dt>
+      <dd>Sets the point in the current buffer to the last buffer position, leaving mark in its current position. <u>C</u></dd>
+      <dt><code>(beginning-of-line)</code></dt>
+      <dd>Sets point before the first character of the current line, leaving mark in its current position. <u>S: move-beginning-of-line</u></dd>
+      <dt><code>(end-of-line)</code></dt>
+      <dd>Sets point after the last character of the current line, i.e. before the end-of-line character sequence, leaving mark in its current position. <u>S: move-end-of-line</u></dd>
+      <dt><code>(forward-word)</code></dt>
+      <dd>Moves the point in the current buffer forward before the first char of the next word. If there is no word left the point is set to the end of the buffer. If the point is already at the start or within a word, the current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>end</em> of the the next word.</dd>
+      <dt><code>(backward-word)</code></dt>
+      <dd>Moves the point in the current buffer backward after the last char of the previous word. If there is no word left the point is set to the beginning of the buffer. If the point is already at the end or within a word, the current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>beginning</em> of the previous word.</dd>
+      <dt><code>(forward-char)</code></dt>
+      <dd>Moves the point in the current buffer one character forward, but not past the end of the buffer. <u>C</u></dd>
+      <dt><code>(backward-char)</code></dt>
+      <dd>Moves the point in the current buffer one character backward, but not before the end of the buffer. <u>C</u></dd>
+      <dt><code>(forward-page)</code></dt>
+      <dd>Moves the point of the current buffer to the beginning of the last visible line of the associated screen and scrolls the screen up to show it as the first line. <u>S: scroll-up</u></dd>
+      <dt><code>(backward-page)</code></dt>
+      <dd>Moves the point of the current buffer to the beginning of the first visible line of the associoated screen and scrolls the screen down to show it as the last line. <u>S: scroll-down</u></dd>
+      <dt><code>(next-line)</code></dt>
+      <dd>Moves the point in the current buffer to the same character position in the next line, or to the end of the next line if there are not enough characters. In the last line of the buffer moves the point to the end of the buffer. <u>C</u></dd>
+      <dt><code>(previous-line)</code></dt>
+      <dd>Movest the point in the current buffer to the same character position in the previous line, or to the end of the previous line if there are not enough characters. In the first line of the buffer the point is not moved. <u>C</u></dd>
+    </dl>
+
+    <h5>Buffer management</h5>
+
+    <dl>
+      <dt><code>(list-buffers)</code></dt>
+      <dd>Lists all the buffers in a buffer called <samp>*buffers*</samp>.</dd>
+      <dt><code>(get-buffer-count)</code></dt>
+      <dd>Returns the number of buffers, includes all special buffers and <samp>*buffers*</samp>.</dd>
+      <dt><code>(select-buffer <var>string</var>)</code></dt>
+      <dd>Makes the buffer named <var>string</var> the current buffer. Note: <u>C</u> to <code>set-buffer</code> in Elisp.</dd>
+      <dt><code>(rename-buffer <var>string</var>)</code></dt>
+      <dd>Rename the current buffer to <var>string</var>. <u>C</u></dd>
+      <dt><code>(kill-buffer <var>string</var>)</code></dt>
+      <dd>Kill the buffer names <var>string</var>. Unsaved changes are discarded. <u>C</u></dd>
+      <dt><code>(get-buffer-name)</code></dt>
+      <dd>Return the name of the current buffer. Note: <u>C</u> to <code>buffer-name</code> in Elisp.</dd>
+      <dt><code>(add-mode-global <var>string</var>)</code></dt>
+      <dd>Sets global mode <var>string</var> for all buffers. Currently the only global mode is <kbd>undo</kbd>.</dd>
+      <dt><code>(find-file <var>string</var>)</code></dt>
+      <dd>Loads file with path string into a new buffer. <u>C</u></dd>
+      <dt><code>(save-buffer <var>string</var>)</code></dt>
+      <dd>Saves the buffer named <var>string</var> to disk. <u>C</u></dd>
+    </dl>
+
+    <h4>User Interaction</h4>
+
+    <p>
+      This section lists function related to <i>window</i> and <i>message line</i> manipulation, <i>keyboard input</i>
+      and system interaction.
+    </p>
+
+    <h5>Window Handling</h5>
+
+    <dl>
+      <dt><code>(delete-other-windows)</code></dt>
+      <dd>Make current window the only window. <u>C</u></dd>
+      <dt><code>(split-window)</code></dt>
+      <dd>Splits the current window. Creates a new window for the current buffer. <u>C</u></dd>
+      <dt><code>(other-window)</code></dt>
+      <dd>
+	Moves the cursor to the next window down on the screen. Makes the buffer in that window the current
+	buffer. <u>D</u>
+      </dd> 
+      <dd>
+	<p>Note: Elisp <code>other-window</code> has a required parameter <var>count</var>, which specifies the number
+	  of windows to move down or up.
+	</p>
+      </dd>
+      <dt><code>(update-display)</code></dt>
+      <dd>Updates all modified windows.</dd>
+      <dt><code>(refresh)</code></dt>
+      <dd>Updates all windows by marking them modified and calling <code>update-display</code>.</dd>
+    </dl>
+
+    <h5>Message Line</h5>
+    <dl>
+      <dt><code>(message <var>string</var>)</code></dt>
+      <dd>Displays <var>string</var> in the message line. <u>D</u></dd>
+      <dt><code>(clear-message-line)</code></dt>
+      <dd>Displays the empty string in the message line.</dd>
+      <dt><code>(prompt <var>prompt</var> <var>default</var>)</code></dt>
+      <dd>
+	Displays <var>prompt</var> in the command line and sets <var>default</var> as initial value for the user
+	respones. The user can edit the response. When hitting return, the final response is returned.
+      </dd>
+      <dt><code>(show-prompt <var>prompt</var> <var>default</var>)</code></dt>
+      <dd>
+	Displays <var>prompt</var> and <var>default</var> in the commandline, but does not allow
+	editing. Returns <code>t</code>.
+      </dd>
+      <dt><code>(prompt-filename <var>prompt</var>)</code></dt>
+      <dd>
+	Displays <var>prompt</var> in the commandline and allows to enter or search for a file name. Returns the
+	relative path to the selected file name or the response typed by the user.
+      </dd>
+    </dl>
+
+    <h5>Keyboard Handling</h5>
+
+    <dl>
+      <dt><code>(set-key <var>key-name</var> <var>lisp-func</var>)</code></dt>
+      <dd>Binds key key-name to the lisp function <var>lisp-func</var>.</dd>
+      <dt><code>(get-key-name)</code></dt>
+      <dd>Returns the name of the currently pressed key, eg: <samp>c-k</samp> for control-k.</dd>
+      <dt><code>(get-key-funcname)</code></dt>
+      <dd>Return the name of the function bound to the currently pressed key.</dd>
+      <dt><code>(execute-key)</code></dt>
+      <dd>Executes the function of the last bound key. <mark>Tbd. bound or pressed?</mark></dd>
+      <dt><code>(describe-bindings)</code></dt>
+      <dd>
+	Creates a listing of all current key bindings, in a buffer named <samp>*help*</samp> and displays it in a new
+	window. <u>C</u>
+      </dd>
+      <dt><code>(describe-functions)</code></dt>
+      <dd>
+	Creates a listing of all functions bound to keys in a buffer named <samp>*help*</samp> and displays it in a new
+	window.
+      </dd>
+      <dt><code>(getch)</code></dt>
+      <dd>
+	Waits for a key to be pressed and returns the key as string. See
+	also <code>get-key-name</code>, <code>get-key-funcname</code> and <code>execute-key</code>.
+      </dd>
+    </dl>
+
+    <h5>Programming and System Interaction</h5>
+
+    <dl>
+      <dt><code>(exit)</code></dt>
+      <dd>Exit Femto without saving modified buffers.</dd>
+      <dt><code>(eval-block)</code></dt>
+      <dd>
+	Evaluates the <var>region</var> in the current buffer, inserts the result at <var>point</var> and returns
+	it. If <var>mark</var> in the current buffer is before <var>point</var> <code>eval-block</code> evaluates
+	this <var>region</var> and inserts the result at <var>point</var>. If <var>point</var> is
+	before <var>mark</var> <code>eval-block</code> does nothing but returning <samp>t</samp>.
+      </dd>
+      <dt><code>(system <var>string</var>)</code></dt>
+      <dd>
+	Executes the <a href="https://man7.org/linux/man-pages/man3/system.3.html">system(1)</a> function
+	with <var>string</var> as parameter.
+      </dd>
+      <dt><code>(os.getenv <var>string</var>) </code></dt>
+      <dd>Returns the value of the environment variable named <var>string</var>.</dd>
+      <dt><code>(log-message <var>string</var>)</code></dt>
+      <dd>Logs <var>string</var> to the <samp>*messages*</samp> buffer. </dd>
+      <dt><code>(log-debug <var>string</var>)</code></dt>
+      <dd>Logs string to the file <code>debug.out</code>.</dd>
+      <dt><code>(get-version-string)</code></dt>
+      <dd>Returns the complete version string of Femto, including the copyright.</dd>
+    </dl>
+    
+    <h3>Implementation Details</h3>
+
+    <p><mark>Tbd.: Memory consumption, limits, hacking, ...</mark></p>
+  </body>
 </html>
+<!--
+    Emacs:
+    Local Variables:
+    fill-column: 120
+    End:
+  -->

--- a/pdoc/flisp.html
+++ b/pdoc/flisp.html
@@ -57,6 +57,29 @@
     </dl>
     <p>Annotation is omitted if the function does not exist in Emacs Lisp.</p>
 
+    <p>We use the following notation rule for the <i>fLisp</i> syntax:</p>
+    <dl>
+      <dt><code><var>name</var></code></dt>
+      <dd>
+	<var>name</var> is the name of a variable. In Markdown documents it is shown with guillements, like
+	this <code>«name»</code>.</dd>
+      <dt><code>[text]</code></dt>
+      <dd><code>text</code> can be given zero or one time.</dd>
+      <dt><code>[text..]</code></dt>
+      <dd><code>text</code> can be given zero or more times.</dd>
+      <dt><q><code> </code></q></dt>
+      <dd>A single space is used to denote an arbitrary sequence of whitespace.</dd>
+    </dl>
+
+    <p>Notes:</p>
+    <ul>
+      <li>
+	<i>fLisp</i> does not use <code>[</code>square brackets<code>]</code> and double-dots <code>..</code> as
+	syntactical elements.
+      </li>
+      <li>String and number notation and formating conventions are the same as in the C language</li>
+    </ul>
+    
     <h4>fLisp Interpreter</h4>
 
     <p>When <i>fLisp</i> is invoked it follows a three step process:</p>
@@ -97,11 +120,11 @@
     <p>Numbers are represented in decimal notation.</p>
     <p>A list of objects has the form:</p>
     <blockquote>
-      <code>(</code>[<code><var>element</var></code>..]<code>)</code>
+      <code>([<var>element</var> ..])</code>
     </blockquote>
     <p>A function invocation has the form:</p>
     <blockquote>
-      <code>(<var>name</var> </code>[<code><var>param</var> </code>..]<code>)</code>
+      <code>(<var>name</var> [<var>param</var> ..])</code>
     </blockquote>
     <p>There are two predefined objects. Their symbols are:</p>
     <dl>
@@ -110,7 +133,7 @@
 	represents: the empty list: <code>()</code>, the end of a list marker or the false value in logical operations.
       </dd>
       <dt><code>t</code></dt>
-      <dd><q>true</q>, a fixed, non-false value.</dd>
+      <dd><q>true</q>, a predefined, non-false value.</dd>
     </dl>
 
     <h4 id="objects_and_data_types">Objects and Data Types</h4>
@@ -134,42 +157,37 @@
       <dd>anonymous function without parameter evaluation</dd>
     </dl>
     <p>
-      Objects are unmutable, all <i>fLisp</i> functions create new objects from existing ones or return existing ones.
+      Objects are unmutable, functions either create new objects or return existing ones.
     </p>
-    <p>Characters do not have their own type. A single character is represented by a <i>string</i> with length 1.</p>
+    <p>Characters do not have their own type. A single character is represented by a <i>string</i> with length one.</p>
 
     <h4>Environments, Functions, Evaluation</h4>
 
     <p>
       All operations of the interpreter take place in an environment. An <dfn>environment</dfn> is a collection of named
-      objects. The object names have the <var>symbol</var> datatype.  An object in an environment is said to
+      objects. The object names are of type symbol.  An object in an environment is said to
       be <dfn>bound</dfn> to its name. Environments can have a parent.  Each <i>fLisp</i> interpreter starts with
       a <dfn>root</dfn> environment without a parent.
     </p>
     <p>
-      <i>lambda</i> and <i>macro</i> objects are functions. They have a parameter list and a <i>sexp</i> as body. When
-      functions are invoked a new environment is created as child of the current environment.
+      lambda and macro objects are functions. They have a parameter list and a sexp as body. When functions are invoked
+      a new environment is created as child of the current environment.  Functions receive zero or more objects from the
+      caller.  These are bound one by one to the symbols in the parameter list in the new environment.
     </p>
+    <p>lambdas return the result of evaluating the body in the new environment.</p>
     <p>
-      Functions receive zero or more objects from the caller.  These are bound one by one to the symbols in the
-      parameter list in the new environment.
-    </p>
-    <p><i>lambda</i>s return the result of evaluating the body in the new environment.</p>
+      macros first evaluate the body in the calling environment. The resulting sexp is evaluated in the new environment
+      and that result is returned.  macro bodies are typically crafted to return new sexp's in terms of the
+      parameters.</p>
     <p>
-      <i>macro</i>s first evaluate the body in the calling environment. The resulting <i>sexp</i> is evaluated in the
-      new environment and that result is returned.
-    </p>
-    <p>
-      <i>macro</i> bodies typically are crafted to return new <i>sexp</i>s in terms of the parameters.
-    </p>
-    <p>
-      When a <i>sexp</i> is evaluated and encounters a <i>symbol</i> it looks it up in the current environment, and
-      then recursively in the environments from which the <var>lambda</var> or <var>macro</var> was invoked.  The symbol
-      of the first binding is then replaced by its object.
+      When a sexp is evaluated and encounters a symbol it looks it up in the current environment, and
+      then recursively in the environments from which the lambda or macro was invoked.  The symbol
+      of the first found binding is then replaced by its object.
     </p>
     <p>
       <i>fLisp</i> counts with a set of built-in functions called <dfn>primitives</dfn>. They are grouped in the manual
-      by the type of objects they operate on.
+      by the type of objects they operate on. The primitives are bound in the global environment to the names under
+      which they are described.
     </p>
 
     <h4>Primitives</h4>
@@ -177,18 +195,20 @@
     <h5>Interpreter Operations</h5>
 
     <dl>
-      <dt><code>(progn</code> [<code><var>expr</var></code> ..]<code>)</code></dt>
-      <dd>Each <var>expr</var> is evaluated, the value of the last is returned.
-      </dd>
-      <dt><code>(cond</code> [<code><var>clause</var></code> ..]<code>)</code></dt>
+      <dt><code>(progn[ <var>expr</var>..])</code></dt>
       <dd>
-	Each <var>clause</var> is of the form <code>(<var>pred</var> [<var>action</var>])</code>. <code>cond</code>
-	evaluates each <var>clause</var> in turn: if <var>pred</var> evaluates to <code>nil</code>, the
-	next <var>clause</var> is tested. Otherwise: if there is no <var>action</var> the value of <var>pred</var> is
-	returned, otherwise <code>(progn <var>action</var>)</code> is returned and no more <var>clause</var>s are
-	evaluated.
+	Each <var>expr</var> is evaluated, the value of the last is returned. If no <var>expr</var> is
+	given, <code>progn</code> returns <code>nil</code>.
       </dd>
-      <dt><code>(setq <var>symbol</var> <var>value</var></code> [<code><var>symbol</var> <var>value</var></code>]..<code>)</code></dt>
+      <dt><code>(cond[ <var>clause</var>..])</code></dt>
+      <dd>
+	Each <var>clause</var> is of the form <code>(<var>pred</var>[ <var>action</var>])</code>. <code>cond</code>
+	evaluates each <var>clause</var> in turn. If <var>pred</var> evaluates to <code>nil</code>, the
+	next <var>clause</var> is tested. If <var>pred</var> evaluates not to <code>nil</code> and if there is
+	no <var>action</var> the value of <var>pred</var> is returned, otherwise <code>(progn <var>action</var>)</code>
+	is returned and no more <var>clause</var>s are evaluated.
+      </dd>
+      <dt><code>(setq <var>symbol</var> <var>value</var>[ <var>symbol</var> <var>value</var>..])</code></dt>
       <dd>
 	Create or update named objects: If <var>symbol</var> is the name of an existing named object in the current or a
 	parent environment the named object is set to <var>value</var>, if no symbol with this name exists, a new one is
@@ -199,24 +219,24 @@
 	Returns a <var>lambda</var> function which accepts 0 or more arguments, which are passed as list in the
 	parameter <var>params</var>.
       </dd> 
-      <dt><code>(lambda (</code>[<code><var>param</var></code> ..]<code>) <var>body</var>)</code></dt>
+      <dt><code>(lambda ([<var>param</var> ..]) <var>body</var>)</code></dt>
       <dd>
 	Returns a <var>lambda</var> function which accepts the exact number of arguments given in the list
 	of <var>param</var>s.
       </dd>
-      <dt><code>(lambda (<var>param</var></code> [<code><var>param</var></code> ..]<code> . <var>opt</var>) <var>body</var>)</code></dt>
+      <dt><code>(lambda (<var>param</var>[ <var>param</var>..] . <var>opt</var>) <var>body</var>)</code></dt>
       <dd>
 	Returns a <var>lambda</var> function which requires at least the exact number of arguments given in the list
 	of <var>param</var>s. All extra arguments are passed as a list in the parameter <var>opt</var>.
       </dd>
       <dt><code>(macro <var>params</var> <var>body</var>)</code></dt>
-      <dt><code>(macro (</code>[<code><var>param</var></code> ..]<code>) <var>body</var>)</code></dt>
-      <dt><code>(macro (<var>param</var></code> [<code><var>param</var></code> ..]<code> . <var>opt</var>) <var>body</var>)</code></dt>
+      <dt><code>(macro ([<var>param</var> ..]) <var>body</var>)</code></dt>
+      <dt><code>(macro (<var>param</var>[ <var>param</var><..] . <var>opt</var>) <var>body</var>)</code></dt>
       <dd>
-	These forms return a <var>macro</var> function. Parameter handling is the same as with <var>lambda</var>.
+	These forms return a macro function. Parameter handling is the same as with lambda.
       </dd>
       <dt><code>(quote <var>expr</var>)</code></dt>
-      <dd>quote returns <var>expr</var> without evaluating it.
+      <dd>Returns <var>expr</var> without evaluating it.
       </dd>
       <dt><code>(signal <var>symbol</var> <var>list</var>)</code></dt>
       <dd>tbd</dd>
@@ -230,17 +250,17 @@
       <dt><code>(null <var>object</var>)</code></dt>
       <dd>Returns <code>t</code> if <var>object</var> is <code>nil</code>, otherwise <code>nil</code>.</dd>
       <dt><code>(symbolp <var>object</var>)</code></dt>
-      <dd>Returns <code>t</code> if <var>object</var> is of type <i>symbol, </i>otherwise <code>nil</code>.</dd>
+      <dd>Returns <code>t</code> if <var>object</var> is of type symbol, otherwise <code>nil</code>.</dd>
       <dt><code>(symbol-name <var>object</var>)</code></dt>
-      <dd>If <var>object</var> is of type <i>symbol</i> return its value as string.</dd>
+      <dd>If <var>object</var> is of type symbol return its value as string.</dd>
       <dt><code>(numberp <var>object</var>)</code></dt>
-      <dd>Returns <code>t</code> if <var>object</var> is of type <i>number</i>, otherwise <code>nil</code>.</dd>
+      <dd>Returns <code>t</code> if <var>object</var> is of type number, otherwise <code>nil</code>.</dd>
       <dt><code>(stringp <var>object</var>)</code></dt>
-      <dd>Returns <code>t</code> if <var>object</var> is of type <i>string</i>, otherwise <code>nil</code>.</dd>
+      <dd>Returns <code>t</code> if <var>object</var> is of type string, otherwise <code>nil</code>.</dd>
       <dt><code>(consp <var>object</var>)</code></dt>
-      <dd>Returns <code>t</code> if <var>object</var> is of type <i>cons</i>, otherwise <code>nil</code>.</dd>
+      <dd>Returns <code>t</code> if <var>object</var> is of type cons, otherwise <code>nil</code>.</dd>
       <dt><code>(cons <var>car</var> <var>cdr</var>)</code></dt>
-      <dd>Returns a new <i>cons</i> with the first object set to the value of <var>car</var> and the second to the value of <var>cdr</var>.</dd>
+      <dd>Returns a new cons with the first object set to the value of <var>car</var> and the second to the value of <var>cdr</var>.</dd>
       <dt><code>(car <var>cons</var>)</code></dt>
       <dd>Returns the first object of <var>cons</var>.</dd>
       <dt><code>(cdr <var>cons</var>)</code></dt>
@@ -295,32 +315,32 @@
     <h5>Arithmetic Operations</h5>
 
     <dl>
-      <dt><code>(+</code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-      <dd>Returns the sum of all <var>arg</var>s or <code>0</code> if none given.</dd>
-      <dt><code>(*</code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dt><code>(+[ <var>arg</var>..])</code></dt>
+      <dd>Returns the sum of all <var>arg</var>s or <code>0</code> if none is given.</dd>
+      <dt><code>(*[ <var>arg</var>..])</code></dt>
       <dd>Returns the product of all <var>arg</var>s or <code>1</code> if none given.</dd>
-      <dt><code>(-</code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dt><code>(-[ <var>arg</var>..])</code></dt>
       <dd>
 	Returns 0 if no <var>arg</var> is given, -<var>arg</var> if only one is given, <var>arg</var> minus the sum of
 	all others otherwise.
       </dd>
-      <dt><code>(/ <var>arg</var></code> [<code><var>div</var></code> ..]<code>)</code></dt>
+      <dt><code>(/ <var>arg</var>[ <var>div</var>..])</code></dt>
       <dd>
-	Returns 1/<var>arg</var> if no <var>div</var> is given, <var>arg</var>/<var>div</var>[/<var>div</var>../] if one
+	Returns 1/<var>arg</var> if no <var>div</var> is given, <var>arg</var>/<var>div</var>[/<var>div</var>..] if one
 	or more <var>div</var>s are given, <code>inf</code> if one of the <var>div</var>s is <code>0</code> and the sum
 	of the signs of all operands is even, <code>-inf</code> if it is odd.
       </dd>
-      <dt><code>(% <var>arg</var></code> [<code><var>div</var></code> ..]<code>)</code></dt>
+      <dt><code>(% <var>arg</var>[ <var>div</var>..])</code></dt>
       <dd>
-	Returns <code>1</code> if no <var>div</var> is given, <var>arg</var>%<var>div</var>[%<var>div</var> ..] if one
+	Returns <code>1</code> if no <var>div</var> is given, <var>arg</var>%<var>div</var>[%<var>div</var>..] if one
 	or more <var>div</var>s are given. If one of the divs is <code>0</code>, the program exits with an arithmetic
 	exception.
       </dd>
-      <dt><code>(= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-      <dt><code>(&lt; <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-      <dt><code>(&gt; <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-      <dt><code>(&lt;= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-      <dt><code>(&gt;= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
+      <dt><code>(= <var>arg</var>[ <var>arg</var>..])</code></dt>
+      <dt><code>(&lt; <var>arg</var>[ <var>arg</var>..])</code></dt>
+      <dt><code>(&gt; <var>arg</var>[ <var>arg</var>..])</code></dt>
+      <dt><code>(&lt;= <var>arg</var>[ <var>arg</var>..])</code></dt>
+      <dt><code>(&gt;= <var>arg</var>[ <var>arg</var>..])</code></dt>
       <dd>
 	These predicate functions apply the respective comparison operator between all <var>arg</var>s and return the
 	respective result as <code>t</code> or <code>nil</code>.  If only one <var>arg</var> is given they all
@@ -343,17 +363,17 @@
 
     <p>
       This section describes the buffer related functions added by Femto to fLisp. The description is separated in
-      function related to buffer management and text manipulation. Buffer management creates, deletes buffers, or
-      selects one of the existing buffers as the <q>current</q> buffer. Text manipulation always operates on the current
-      buffer.
+      function related to buffer management and text manipulation.  Text manipulation always operates on
+      the <dfn>current buffer</dfn>. Buffer management creates, deletes buffers, or selects one of the existing buffers
+      as the current buffer.  current buffercode.
     </p>
 
     <p>Buffers store text and allow to manipulate it. A buffer has the following properties:</p>
     <dl>
       <dt><var>name</var></dt>
       <dd>
-	Buffers are identified by their name. If a buffer name is enclosed in *asterisks* the buffer receives special
-	treatment.
+	Buffers are identified by their name. If a buffer name is enclosed in <samp>*</samp>asterisks<samp>*</samp> the
+	buffer receives special treatment.
       </dd>
       <dt><var>text</var></dt>
       <dd>0 or more characters.</dd>
@@ -370,14 +390,16 @@
       <dd>Different flags determine the behaviour of the buffer.</dd>
     </dl>
 
+    <p>In the following, all mentions of these variables refer to the current buffers properties.</p>
+    
     <h5>Text manipulation</h5>
 
     <dl>
       <dt><code>(insert-string <var>string</var>)</code></dt>
-      <dd>Inserts <var>string</var> at <i>point</i>. <u>S: insert</u>.</dd>
+      <dd>Inserts <var>string</var> at <var>point</var>. <u>S: insert</u>.</dd>
       <dt><code>(insert-file-contents-literally <var>string</var> </code>[<code><var>flag</var></code>]<code>)</code></dt>
       <dd>
-	Inserts the file <var>string</var> after <i>point</i>. If <var>flag</var> is not nil the buffer is marked as not
+	Inserts the file <var>string</var> after <var>point</var>. If <var>flag</var> is not nil the buffer is marked as not
 	modified. <u>B</u>
       </dd>
       <dd>
@@ -390,17 +412,17 @@
       <dt><code>(erase-buffer)</code></dt>
       <dd>Erases all text in the current buffer. <u>C</u></dd>
       <dt><code>(delete)</code></dt>
-      <dd>Deletes the character after <i>point</i>. <u>S: delete-char</u></dd>
+      <dd>Deletes the character after <var>point</var>. <u>S: delete-char</u></dd>
       <dt><code>(backspace)</code></dt>
-      <dd>Deletes the character to the left of <i>point</i>. <u>S: delete-backward-char</u></dd>
+      <dd>Deletes the character to the left of <var>point</var>. <u>S: delete-backward-char</u></dd>
       <dt><code>(get-char)</code></dt>
-      <dd>Returns the character to the left of <i>point</i>. <u>S: get-byte</u></dd>
+      <dd>Returns the character to the left of <var>point</var>. <u>S: get-byte</u></dd>
       <dt><code>(copy-region)</code></dt>
-      <dd>Copies <i>region</i> to the <i>clipboard</i>. <u>S: copy-region-as-kill</u></dd>
+      <dd>Copies <var>region</var> to the <var>clipboard</var>. <u>S: copy-region-as-kill</u></dd>
       <dt><code>(kill-region)</code></dt>
-      <dd>Deletes the text in the <i>region</i> and copies it to the <i>clipboard</i>. <u>D</u></dd>
+      <dd>Deletes the text in the <var>region</var> and copies it to the <var>clipboard</var>. <u>D</u></dd>
       <dt><code>(yank)</code></dt>
-      <dd>Pastes the <i>clipboard</i> before <i>point</i>. <u>C</u></dd>
+      <dd>Pastes the <var>clipboard</var> before <var>point</var>. <u>C</u></dd>
     </dl>
 
     <h5>Selection</h5>
@@ -415,9 +437,9 @@
       <dt><code>(get-point-max)</code></dt>
       <dd>Returns the maximum accessible value of point in the current buffer. <u>S: point-max</u></dd>
       <dt><code>(set-clipboard <var>variable</var>)</code></dt>
-      <dd><code>Sets <i>clipboard</i> to the contents of <var>variable</var>.</code> <u>S: gui-set-selection</u></dd>
+      <dd><code>Sets <var>clipboard</var> to the contents of <var>variable</var>.</code> <u>S: gui-set-selection</u></dd>
       <dt><code>(get-clipboard)</code></dt>
-      <dd>Returns the <i>clipboard</i> contents.  <u>S: gui-get-selection</u></dd>
+      <dd>Returns the <var>clipboard</var> contents.  <u>S: gui-get-selection</u></dd>
     </dl>
 
     <h5>Cursor Movement</h5>
@@ -426,35 +448,82 @@
       <dt><code>(set-point <var>number</var>)</code></dt>
       <dd>Sets the point to in the current buffer to the position <var>number</var>. <u>S: goto-char</u></dd>
       <dt><code>(goto-line <var>number</var>)</code></dt>
-      <dd>Sets the point in the current buffer to the first character on line <var>number</var>. <u>S: goto-line</u>, not an Elisp function.</dd>
+      <dd>
+	Sets the point in the current buffer to the first character on line <var>number</var>. <u>S: goto-line</u>, not
+	an Elisp function.
+      </dd>
       <dt><code>(search-forward <var>string</var>)</code></dt>
-      <dd>Searches for <var>string</var> in the current buffer, starting from point forward. If string is found, sets the point after the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone and returns <samp>nil</samp>. <u>D</u></dd>
+      <dd>
+	Searches for <var>string</var> in the current buffer, starting from point forward. If string is found, sets the
+	point after the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone
+	and returns <samp>nil</samp>. <u>D</u>
+      </dd>
       <dt><code>(search-backward <var>string</var>)</code></dt>
-      <dd>Searches for <var>string</var> in the current buffer, starting from point backwards. If string is found, sets the point before the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone and returns <samp>nil</samp>. <u>D</u></dd>
+      <dd>
+	Searches for <var>string</var> in the current buffer, starting from point backwards. If string is found, sets
+	the point before the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point
+	alone and returns <samp>nil</samp>. <u>D</u>
+      </dd>
       <dt><code>(beginning-of-buffer)</code></dt>
-      <dd>Sets the point in the current buffer to the first buffer position, leaving mark in its current position. <u>C</u></dd>
+      <dd>
+	Sets the point in the current buffer to the first buffer position, leaving mark in its current
+	position. <u>C</u>
+      </dd>
       <dt><code>(end-of-buffer)</code></dt>
-      <dd>Sets the point in the current buffer to the last buffer position, leaving mark in its current position. <u>C</u></dd>
+      <dd>
+	Sets the point in the current buffer to the last buffer position, leaving mark in its current position. <u>C</u>
+      </dd>
       <dt><code>(beginning-of-line)</code></dt>
-      <dd>Sets point before the first character of the current line, leaving mark in its current position. <u>S: move-beginning-of-line</u></dd>
+      <dd>
+	Sets point before the first character of the current line, leaving mark in its current position. <u>S:
+	  move-beginning-of-line</u>
+      </dd>
       <dt><code>(end-of-line)</code></dt>
-      <dd>Sets point after the last character of the current line, i.e. before the end-of-line character sequence, leaving mark in its current position. <u>S: move-end-of-line</u></dd>
+      <dd>
+	Sets point after the last character of the current line, i.e. before the end-of-line character sequence, leaving
+	mark in its current position. <u>S: move-end-of-line</u>
+      </dd>
       <dt><code>(forward-word)</code></dt>
-      <dd>Moves the point in the current buffer forward before the first char of the next word. If there is no word left the point is set to the end of the buffer. If the point is already at the start or within a word, the current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>end</em> of the the next word.</dd>
+      <dd>
+	Moves the point in the current buffer forward before the first char of the next word. If there is no word left
+	the point is set to the end of the buffer. If the point is already at the start or within a word, the current
+	word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>end</em> of the the next word.
+      </dd>
       <dt><code>(backward-word)</code></dt>
-      <dd>Moves the point in the current buffer backward after the last char of the previous word. If there is no word left the point is set to the beginning of the buffer. If the point is already at the end or within a word, the current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>beginning</em> of the previous word.</dd>
+      <dd>
+	Moves the point in the current buffer backward after the last char of the previous word. If there is no word
+	left the point is set to the beginning of the buffer. If the point is already at the end or within a word, the
+	current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>beginning</em> of the previous word.
+      </dd>
       <dt><code>(forward-char)</code></dt>
       <dd>Moves the point in the current buffer one character forward, but not past the end of the buffer. <u>C</u></dd>
       <dt><code>(backward-char)</code></dt>
-      <dd>Moves the point in the current buffer one character backward, but not before the end of the buffer. <u>C</u></dd>
+      <dd>
+	Moves the point in the current buffer one character backward, but not before the end of the
+	buffer. <u>C</u>
+      </dd> 
       <dt><code>(forward-page)</code></dt>
-      <dd>Moves the point of the current buffer to the beginning of the last visible line of the associated screen and scrolls the screen up to show it as the first line. <u>S: scroll-up</u></dd>
+      <dd>
+	Moves the point of the current buffer to the beginning of the last visible line of the associated screen and
+	scrolls the screen up to show it as the first line. <u>S: scroll-up</u>
+      </dd>
       <dt><code>(backward-page)</code></dt>
-      <dd>Moves the point of the current buffer to the beginning of the first visible line of the associoated screen and scrolls the screen down to show it as the last line. <u>S: scroll-down</u></dd>
+      <dd>
+	Moves the point of the current buffer to the beginning of the first visible line of the associoated screen and
+	scrolls the screen down to show it as the last line. <u>S: scroll-down</u>
+      </dd>
       <dt><code>(next-line)</code></dt>
-      <dd>Moves the point in the current buffer to the same character position in the next line, or to the end of the next line if there are not enough characters. In the last line of the buffer moves the point to the end of the buffer. <u>C</u></dd>
+      <dd>
+	Moves the point in the current buffer to the same character position in the next line, or to the end of the next
+	line if there are not enough characters. In the last line of the buffer moves the point to the end of the
+	buffer. <u>C</u>
+      </dd>
       <dt><code>(previous-line)</code></dt>
-      <dd>Movest the point in the current buffer to the same character position in the previous line, or to the end of the previous line if there are not enough characters. In the first line of the buffer the point is not moved. <u>C</u></dd>
+      <dd>
+	Moves the point in the current buffer to the same character position in the previous line, or to the end of the
+	previous line if there are not enough characters. In the first line of the buffer the point is not
+	moved. <u>C</u>
+      </dd>
     </dl>
 
     <h5>Buffer management</h5>
@@ -483,8 +552,8 @@
     <h4>User Interaction</h4>
 
     <p>
-      This section lists function related to <i>window</i> and <i>message line</i> manipulation, <i>keyboard input</i>
-      and system interaction.
+      This section lists function related to window and message line manipulation, keyboard input and system
+      interaction.
     </p>
 
     <h5>Window Handling</h5>

--- a/pdoc/h2m.lua
+++ b/pdoc/h2m.lua
@@ -1,0 +1,36 @@
+--local logging = require 'logging'
+local function index(list,needle)
+   for i,element in ipairs(list) do
+      if element == needle then return i end
+   end
+end
+return {
+   {
+      Inlines = function(list)
+	 local l = pandoc.List {}
+	 for i,elem in ipairs(list) do
+	    if elem.tag == 'Code' then
+	       local last = l[#l]
+	       if last and last.tag == 'Code' and not index(last.attr.classes, 'variable')  then
+		  l:remove()
+		  local text = elem.text
+		  if index(elem.attr.classes, 'variable') then
+		     text = '«'..text..'»'
+		  end
+		  combined = pandoc.Code(last.text..text, last.attr)
+		  l:insert(combined)
+	       else
+		  if index(elem.attr.classes, 'variable') then
+		     l:insert(pandoc.Emph(elem.text))
+		  else
+		     l:insert(elem)
+		  end
+	       end
+	    else
+	       l:insert(elem)
+	    end
+	 end
+	 return l
+      end
+   }
+}


### PR DESCRIPTION
This PR adds the fLisp documentation in Github flavoured Markdown to the doc directory.

Unfortunately the rendering on Github is dissapointing, partly because the HTML source file extensively makes use of definition lists, which are not supported by Github flavoured Markdown.

