### PR TITLE
Rmkx home end keys

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -46,24 +46,3 @@ Error 2 related to ptr()
 ==73622==    by 0x10E35D: growgap (gap.c:30)
 ==73622==    by 0x110135: find_buffer (buffer.c:102)
 ==73622==    by 0x10B548: main (main.c:28)
-
-Error 3 found
--------------
-
-==73622== 2,607 bytes in 1 blocks are definitely lost in loss record 179 of 188
-==73622==    at 0x48407B4: malloc (vg_replace_malloc.c:381)
-==73622==    by 0x1145D6: streamGetc (lisp.c:573)
-==73622==    by 0x11468E: readNext (lisp.c:638)
-==73622==    by 0x1178AC: peekNext (lisp.c:649)
-==73622==    by 0x1178AC: load_file_body (lisp.c:2141)
-==73622==    by 0x1179FD: load_file (lisp.c:2156)
-==73622==    by 0x117A9F: e_load (lisp.c:1493)
-==73622==    by 0x116C85: evalExpr (lisp.c:1971)
-==73622==    by 0x117C1F: call_lisp_body (lisp.c:2177)
-==73622==    by 0x117EA1: call_lisp (lisp.c:2221)
-==73622==    by 0x10B5F8: main (main.c:48)
-
-Missing free() for input stream buffer: lisp.c:2148
-
-streamGetc() with STREAM_TYPE_FILE is allocating memory where the whole file is
-read in.

--- a/BUGS
+++ b/BUGS
@@ -5,8 +5,6 @@ BUGS encountered during fLisp refactoring and batch mode
 
 - The status line has a ' ' space before the buffer name, but none after.
 
-- (insert-file) is not documented.
-
 - dired:
   - when entering the second subdirectory loop stops
   - sometimes scrolling up down loop stops

--- a/CHANGE.LOG.md
+++ b/CHANGE.LOG.md
@@ -1,4 +1,24 @@
-## Femto 2.19 11 November 2024
+## Femto 2.20 18 October 2024
+
+fLisp input/output is now based on libc file I/O instead of the
+original Stream emulation.  The interpreter is extended with a stream
+object type. The load_file() function has been eliminated, the (load)
+function switches streams instead.
+
+The Lisp reader now does overflow/underflow checking of numbers.
+
+The build system allows to enable interpreter extensions at build
+time, the editor functions are available via the
+FLISP_EDITOR_EXTENSION and there is a demo FLISP_FILE_EXTENSION, which
+exposes the stream functionality to Lisp.
+
+A simplistic standalone Lisp interpreter can be built via the `flisp`
+target and a README.flisp.md file is provided.
+
+Code has been extensibly documented in the source.
+
+
+## Femto 2.19 11 October 2024
 
 Change in the public C interface of the fLisp interpreter, which
 allows for improved error handling.  The rework also resolved some

--- a/CHANGE.LOG.md
+++ b/CHANGE.LOG.md
@@ -1,3 +1,14 @@
+## Femto 2.19 11 November 2024
+
+Change in the public C interface of the fLisp interpreter, which
+allows for improved error handling.  The rework also resolved some
+segmentation fault issues and uncovered a (not yet fixed) bug in the
+garbage collector.  To mitigate, the default object memory size is
+increased to 4 MByte.
+
+The documentation is corrected and vastly extended.
+
+
 ## Femto 2.18 27 March 2024
 
 This version features a major refactoring of the Lisp related code,
@@ -23,8 +34,13 @@ Tiny-Lisp as in femto code.
 ## Femto 2.17 08 December 2023
 * When the environment variable FEMTO_BATCH exists, femto runs in batch mode
 * When the environment variable FEMTO_DEBUG exists, femto writes some internal logging to debug.log
-* When the environment variable FEMTORC is set, femto interprets its value as the path to the init file and tries to load it instead of the default init_file.
-* A new primitive (signal 'error-symbol error-details) has been added. It throws an exception. The interface is built analogous to Elisp. It was just used for testing, but might be useful in the future anyway.
+* When the environment variable FEMTORC is set, femto interprets its
+  value as the path to the init file and tries to load it instead of
+  the default init_file.
+* A new primitive (signal 'error-symbol error-details) has been
+  added. It throws an exception. The interface is built analogous to
+  Elisp. It was just used for testing, but might be useful in the
+  future anyway.
 
 ## Femto 2.16 08 December 2023
 * code reformatted into K&R using 4 spaces for indents

--- a/README.flisp.md
+++ b/README.flisp.md
@@ -1,0 +1,102 @@
+# fLisp
+
+fLisp is a tiny yet practical interpreter for a dialect of the Lisp
+programming language. It is designed to be embeddable in applications
+as extension language.
+
+fLisp is embedded into the
+(Femto)[https://github.com/hughbarney/femto] editor.
+
+> A designer knows he has achieved perfection not when there is
+> nothing left to add, but when there is nothing left to take away.
+> -- <cite>Antoine de Saint-Exupery</cite>
+
+
+## Why the name fLisp
+
+The choice felt on "fLisp", since femtolisp is already taken (by a not
+so "femto" Lisp interpreter). Lower case "f" stands for the femto
+metric prefix which represents 10^-15 — a very small number.  fLisp is
+meant to be very small.
+
+
+## Goals of fLisp
+
+- To be the smallest embeddable Lisp interpreter yet powerful enough  
+  to drive real world applications.
+- To be rock stable, predictable and consistent.
+- To consume as little resources as possible.
+- To be easy to understand without extensive study (to encourage further  
+  experimentation).
+
+
+## History
+
+The (Femto)[https://github.com/hughbarney/femto] editor came initially
+with a modified version of
+(Tiny-Lisp)[https://github.com/matp/tiny-lisp] by Matthias Pirstitz.
+
+In 2023 some severe bugs surfaced in Tiny-Lisp.  Georg Lehner decided,
+that simplifying the code would help finding them and started
+refactoring both C and Lisp code of the Femto project.
+
+- Lisp startup code is loaded from a file, instead of baking it  
+  into the C - code.
+- Command line arguments are handed over to Lisp.
+- A Lisp library directory can be defined at compile time.
+- The core Lisp functions are reduced to the bare minimum, all  
+  functions which can be derived in Lisp are factored out into a core,  
+  flisp, stdlib and femto Lisp library.
+- Lisp functions are made consistent with  
+  (Elisp)[https://www.gnu.org/software/emacs/manual/elisp.html] or  
+  (Common Lisp)[https://lisp-lang.org] as far as it seems to make  
+  sense.
+
+The amount of deviation gave merit to renaming the Lisp interpreter
+from Tiny-Lisp to fLisp.
+
+In 2024 Georg Lehner decided to improve error and input stream
+handling in order to diagnose further known bugs. This lead again to a
+rewrite of a great part of the code base:
+
+- A stream object type is added to the Lisp core, together with the  
+  minimum primitives needed for the Lisp reader and writer.
+- An extension mechanism is added to the build system, which allows to  
+  build the Lisp core alone, or together with a selection of C  
+  extensions.
+- The femto related C - extensions are separated out into an  
+  extensions.
+- A minimal file extensions exposes the core stream function plus some  
+  additional functions for testing.
+- The C interface of the fLisp interpreter is changed: an fLisp  
+  interpreter is instantiated via the `lisp_init()` function, which  
+  returns an interpreter "object".  This is configured with input,  
+  output and debug streams and then used for the invocation of  
+  `lisp_eval()` or `lisp_eval_string()`. This re-architecturing allows  
+  for centralized access to the interpreters state.
+- A command line wrapper `flisp` is added, which implements a simple
+  repl using only the Lisp core plus the file extension.
+
+## Building
+
+fLisp should be buildable with only the standard C libraries.
+
+    make flisp
+
+# TODO
+
+## Immediate
+
+- Document interpreter input/output streams and file extension
+- check batch mode, maybe remove it
+
+## Future
+
+- Allocate Lisp garbage collected memory dynamically and without  
+  limits.
+- Adapt build system to be able to un/install `flisp` binary. Includes  
+  preparing a Lisp library and a startup file.
+- Adapt test suite to current interpreter and extend coverage.
+- Extend file extension to be usable for Lisp programs.
+- Refactor complete core to be able to run any number of interpreters.
+- Tap the potential of the in code documentation via Doxygen.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Femto
-Femto is an extended version of Atto Emacs with a Tiny Lisp extension languauge
+
+Femto is an extended version of Atto Emacs with a tiny Lisp extension
+language.
 
 ![Femto screenshot](https://github.com/hughbarney/femto/blob/master/screenshots/femto-hilite.png)
 
 ![Femto screenshot](https://github.com/hughbarney/femto/blob/master/screenshots/femto-startup.jpg)
 
-> A designer knows he has achieved perfection not when there is nothing left to add, but when there is nothing left to take away.
+> A designer knows he has achieved perfection not when there is
+> nothing left to add, but when there is nothing left to take away.
 > -- <cite>Antoine de Saint-Exupery</cite>
 
 ## Goals of Femto Emacs
@@ -60,7 +63,8 @@ buffers in mutliple windows, cut, copy and paste; forward and reverse
 searching, a replace function and basic syntax hilighting. The proviso
 being that all this will fit in less than 2000 lines of C.
 
-Femto is an extended version of Atto Emacs with its own extension languauge
+Femto is an extended version of Atto Emacs with its own extension
+language.
 
 
 ## History
@@ -92,28 +96,30 @@ For a full version history please refer to the file [CHANGE.LOG.md](./CHANGE.LOG
 
 ## Comparisons with Other Emacs Implementations
 
-Femto has almost the same level of functionality as MicroEmacs 3.10 for a codebase 1/10 of the size.
+Femto has almost the same level of functionality as MicroEmacs 3.10
+for a codebase about 15% of the size.
 
     Editor         Binary   BinSize     KLOC  Files
 
-    atto           atto       33002     1.9k     10
-    pEmacs         pe         59465     5.7K     16
-    Esatz-Emacs    ee         59050     5.7K     14
-    femto          femto     108408     6.7k     18/31 **
-    GNOME          GNOME      55922     9.8k     13
-    Zile           zile      257360    11.7k     48
-    Mg             mg        585313    16.5K     50
-    uEmacs/Pk      em        147546    17.5K     34
-    Pico           pico      438534    24.0k     29
-    Nano           nano      192008    24.8K     17
-    jove           jove      248824    34.7k     94
-    Qemacs         qe        379968    36.9k     59
-    ue3.10         uemacs    171664    52.4K     16 ++
-    GNUEmacs       emacs   14632920   358.0k    186
+    atto           atto       33002     1.9k      10
+    pEmacs         pe         59465     5.7K      16
+    Esatz-Emacs    ee         59050     5.7K      14
+    femto          femto     120872     8.9k/6.3k 20/30 **
+    GNOME          GNOME      55922     9.8k      13
+    Zile           zile      257360    11.7k      48
+    Mg             mg        585313    16.5K      50
+    uEmacs/Pk      em        147546    17.5K      34
+    Pico           pico      438534    24.0k      29
+    Nano           nano      192008    24.8K      17
+    jove           jove      248824    34.7k      94
+    Qemacs         qe        379968    36.9k      59
+    ue3.10         uemacs    171664    52.4K      16 ++
+    GNUEmacs       emacs   14632920   358.0k     186
 
 Since femto 2.12 C code has been moved out to Lisp. The first number
-in the files count are the C-files plus the minimal required femto.rc
-Lisp file. The second number includes all provided Lisp files.
+in the KLOC column is the line count, the second the sloccount. The
+first number in the files count are the C-files, the second number
+includes the required Lisp files.
 
 
 ## Femto Key Bindings
@@ -203,8 +209,6 @@ Generally, the procedure for copying or moving text is:
     ESC will escape from the search prompt and return to the point of the match
     C-G abort the search and return to point before the search started
 
-
-
 ## Lisp Interaction
 
 There are two ways to interract with Tiny-Lisp within Femto.
@@ -272,12 +276,15 @@ compile time by changing SCRIPTDIR.  At startup `femto` overrides the
 default with the value of the environment variable FEMTOLIB if set.
 
 
+<!-- Batch mode is currently not available and might be deprecated in -->
+<!-- future versions -->
+<!--
 ## Batch Mode
 
 If the environment variable FEMTO_BATCH exists and is not set to `0`
 batch mode is enabled.  In batch mode the GUI is not started up and
 all Lisp output is sent to `stdout`.
-
+-->
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ Lisp file. The second number includes all provided Lisp files.
     C-P   previous line
     C-R   search-backwards
     C-S	  search-forwards
+	C-T   transpose-chars
     C-U   Undo
     C-V   Page Down
     C-W   Kill Region (Cut)
     C-X   CTRL-X command prefix
     C-Y   Yank (Paste)
+	C-Z   suspend
 
     M-<   Start of file
     M->   End of file
@@ -321,6 +323,7 @@ Lisp library functions:
 * `describe-key`
 * `find_start_p`, `find_end_p`, `find_and_eval_sexp` - Lisp evaluation
   in buffers.
+* `transpose-chars` - swap current end previous character.
 
 `startup.lsp` loads extensions, creates key bindings for them, shows
 the startup message, loads the user specified configuration file and

--- a/README.md
+++ b/README.md
@@ -10,19 +10,40 @@ Femto is an extended version of Atto Emacs with a Tiny Lisp extension languauge
 
 ## Goals of Femto Emacs
 
-* To be an extendable version of the Atto Emacs editor using a Tiny Lisp extension language
-* Provide a number of useful extension packages written in Tiny Lisp (these include an interface to **git** (similar to GNU Emacs Magit), a small version of **dired**, a buffer management menu (**buffer menu**), **defmacro** allows for a macro to be recorded and invoked using c-x e, and an interface to **grep**.
-* Be easy to understand without extensive study (to encourage further experimentation).
+* To be an extendable version of the Atto Emacs editor using a Tiny
+  Lisp extension language
+* Provide a number of useful extension packages written in Tiny Lisp
+  (these include an interface to **git** (similar to GNU Emacs Magit),
+  a small version of **dired**, a buffer management menu (**buffer
+  menu**), **defmacro** allows for a macro to be recorded and invoked
+  using c-x e, and an interface to **grep**.
+* Be easy to understand without extensive study (to encourage further
+  experimentation).
 
 
 ## What does Femto bring to the party of Text Editors
 
-As far as I know Femto is the only Emacs style editor to provide a macro recorder that generates usable Lisp code that can then be used to build a larger, more complex utility.   Whilst GNU Emacs has a macro recorder facility it only allows you to dump out the keystrokes used during macro recording.  Femto does this by writing the lisp code to a text buffer called **macro**.  Though I have tried dozens of text editors over the years (mostly on PCs, but a few on mini and mainframe computers) I am not aware of any other editor that works this way.  This feature was born out of the principle of keeping a small editor code written in C and where possible using Lisp to implement new features.  The standard Emacs macro keystrokes [C-x (, C-c ), C-x e] are all written in Lisp in the file examples/defmacro.lsp. This meant that no special C code was needed in Femto to know when it was in macro mode or not.
+As far as I know Femto is the only Emacs style editor to provide a
+macro recorder that generates usable Lisp code that can then be used
+to build a larger, more complex utility.  Whilst GNU Emacs has a macro
+recorder facility it only allows you to dump out the keystrokes used
+during macro recording.  Femto does this by writing the lisp code to a
+text buffer called **macro**.  Though I have tried dozens of text
+editors over the years (mostly on PCs, but a few on mini and mainframe
+computers) I am not aware of any other editor that works this way.
+This feature was born out of the principle of keeping a small editor
+code written in C and where possible using Lisp to implement new
+features.  The standard Emacs macro keystrokes [C-x (, C-c ), C-x e]
+are all written in Lisp in the file examples/defmacro.lsp. This meant
+that no special C code was needed in Femto to know when it was in
+macro mode or not.
 
 
 ## Why the name Femto?
 
-The small Emacs naming scheme appears to use sub-unit prefixes in decending order with each further reduction of functionality. The Nano and Pico Emacs editors have been around for a while.
+The small Emacs naming scheme appears to use sub-unit prefixes in
+decending order with each further reduction of functionality. The Nano
+and Pico Emacs editors have been around for a while.
 
 * Nano means 10 to the power of minus 9
 * Pico means 10 to the power of minus 12 
@@ -31,19 +52,39 @@ The small Emacs naming scheme appears to use sub-unit prefixes in decending orde
 * Zepto means 10 to the power of minus 21
 * Zep is smaller version of Zepto Emacs 
 
-In Defining Atto as the lowest functional Emacs I have had to consider the essential feature set that makes Emacs, 'Emacs'. I have defined this point as a basic Emacs command set and key bindings; the ability to edit multiple files (buffers), and switch between them; edit the buffers in mutliple windows, cut, copy and paste; forward and reverse searching, a replace function and basic syntax hilighting. The proviso being that all this will fit in less than 2000 lines of C.
+In Defining Atto as the lowest functional Emacs I have had to consider
+the essential feature set that makes Emacs, 'Emacs'. I have defined
+this point as a basic Emacs command set and key bindings; the ability
+to edit multiple files (buffers), and switch between them; edit the
+buffers in mutliple windows, cut, copy and paste; forward and reverse
+searching, a replace function and basic syntax hilighting. The proviso
+being that all this will fit in less than 2000 lines of C.
 
 Femto is an extended version of Atto Emacs with its own extension languauge
 
 
 ## History
 
-* In late 2015 Hugh Barney wrote the Atto editor 'A minimum functioning Emacs is less than 2000 lines of C'.  Atto was based on Anthony Howe's editor (commonly known as Anthony's Editor or AE, [2]). 
+* In late 2015 Hugh Barney wrote the Atto editor 'A minimum
+  functioning Emacs is less than 2000 lines of C'.  Atto was based on
+  Anthony Howe's editor (commonly known as Anthony's Editor or AE,
+  [2]).
 * **Femto** is based on the Atto codebase [0]
-* **Femto** was originally an intermediate project to form a codebase for the FemtoEmacs Editor [8], [9] which was a collaboration between Hugh Barney, Ed Costa and Lucas Guerra.  FemtoEmacs uses Jeff Bezanson's Femtolisp LISP [10] implementation as the basis for its extension language.  However the Femtolisp codebase is in excess of 12K line of code and fairly difficult to understand how to use it inside an embedded application.
-* In late 2016 Hugh Barney decided to look for a smaller lisp implementation for Femto and settled on Tiny-Lisp[7] by Mattias Pirstitz.
-* **Zepl** was an initial project that established the suitability of Tiny-Lisp for use within an Emacs type editor. The results surpassed expectations.
-* In late 2017 Hugh Barney decided to return to the **Femto** editor and extend it using Tiny-Lisp.
+* **Femto** was originally an intermediate project to form a codebase
+  for the FemtoEmacs Editor [8], [9] which was a collaboration between
+  Hugh Barney, Ed Costa and Lucas Guerra.  FemtoEmacs uses Jeff
+  Bezanson's Femtolisp LISP [10] implementation as the basis for its
+  extension language.  However the Femtolisp codebase is in excess of
+  12K line of code and fairly difficult to understand how to use it
+  inside an embedded application.
+* In late 2016 Hugh Barney decided to look for a smaller lisp
+  implementation for Femto and settled on Tiny-Lisp[7] by Mattias
+  Pirstitz.
+* **Zepl** was an initial project that established the suitability of
+  Tiny-Lisp for use within an Emacs type editor. The results surpassed
+  expectations.
+* In late 2017 Hugh Barney decided to return to the **Femto** editor
+  and extend it using Tiny-Lisp.
 * In 2023/24 Georg Lehner refactored the Lisp infrastructure.
 
 For a full version history please refer to the file [CHANGE.LOG.md](./CHANGE.LOG.md)
@@ -246,16 +287,52 @@ invocations of the `log-debug` Lisp primitive.
 
 ## Basic Femto Extension
 
-`femto.rc` and `femto.lsp` extend the Lisp editor and provide basic editor functionality.
+`femto.rc` implements a simple library loader and handles batch
+mode. It provides the 'core' functionality.
+
+Standard Lisp function:
+
+* `defmacro`, `defun`, `string`, `concat`, `memq`, 
+
+Lisp library functions:
+
+* `require` auto-loads a 'feature' from the library if not already
+  loaded.
+* `provides` is used to specify a 'feature' in a library file, it
+  must be the same as the filename without the '.lsp' extension.
+
+`flisp.lsp` complements commonly known standard lisp functions:
+
+* `not`, `listp`, `and`, `map1`, `or`, `reduce`, `max`, `min`, `nthcdr`
+
+`femto.lsp` extend the Lisp editor and provide basic editor functionality.
 
 * `load-script` *`file`* - load file from script directory.
-* `edit-config` - open user specific configuration file in Femto.
 * `delete-next-word`, `delete-previous-word`, `kill-to-eol` - For Emacs like key bindings
 * `describe-key`, `find_end_p`, `find_start_p`, `find_and_eval_sexp`, `show-startup-message`
-* `concat` *`args`*, `string.trim.front` *`s`*, `string.trim.back` *`s`*, `string.trim` *`s`*, `shrink` *`s`* - string operations
-* `max` *`a b`*, `min` *`a b`*, `repeat` *`n func`* - Lisp functions
+* `string.trim.front` *`s`*, `string.trim.back` *`s`*, `string.trim` *`s`*, `shrink` *`s`* - string operations
+* `repeat` *`n func`* - Lisp functions
 * `is_ctl_g` *`k`*, `is_escape` *`k`*, `is_backspace` *`k`*, `is_ctl_s` *`k`*, `is_control_char` *`k`* - helper functions
-* `shell-command` - backwards compatibility wrapper for `system`.
+* `shell-command` - backwards compatibility wrapper for `system`,
+  reads command line interactively.
+* `shell-exec` *`command`* - convenience wrapper for `system`, used by `shell-command`.
+* `insert-file` - prompts for a file name with incremental search and
+  inserts it after the point.
+* `describe-key`
+* `find_start_p`, `find_end_p`, `find_and_eval_sexp` - Lisp evaluation
+  in buffers.
+
+`startup.lsp` loads extensions, creates key bindings for them, shows
+the startup message, loads the user specified configuration file and
+processes the command line arguments.  `~/.config/femto/femto.rc`.  It
+defines the following functions:
+
+* `getopts` *`opts`* *`pos`* - process commandline options starting
+  from position pos.
+* `show-startup-message` - shows the startup banner in the \*scratch* buffer.
+* `edit-config` - open user specific configuration file in Femto.
+* `show-info` - load the `info.lsp` file.
+
 
 ## Femto Extensions
 
@@ -346,7 +423,11 @@ The following enhancements are envisaged.
 
 ## Known Issues
 
-Goto-line will fail to go to the very last line.  This is a special case that could easily be fixed.
+Goto-line will fail to go to the very last line.  This is a special
+case that could easily be fixed.
+
+Adding a line at the bottom of a window will hide the line until the
+cursor moves up and down again or the screen is refreshed.
 
 
 ## Coding Style

--- a/buffer.c
+++ b/buffer.c
@@ -12,6 +12,7 @@ void buffer_init(buffer_t *bp)
     bp->b_cpoint = 0;
     bp->b_page = 0;
     bp->b_epage = 0;
+    bp->b_reframe = 0;
     bp->b_size = 0;
     bp->b_psize = 0;
     bp->b_flags = 0;

--- a/command.c
+++ b/command.c
@@ -609,6 +609,7 @@ void match_parens()
     if (buffer_is_empty(bp))
         return;
 
+    // Note: valgrind: Invalid read of size 1
     char p = *ptr(bp, bp->b_point);
 
     switch(p) {

--- a/command.c
+++ b/command.c
@@ -70,7 +70,7 @@ void right()
 
 
 /*
- * work out number of bytes based on first byte 
+ * work out number of bytes based on first byte
  *
  * 1 byte utf8 starts 0xxxxxxx  00 - 7F : 000 - 127
  * 2 byte utf8 starts 110xxxxx  C0 - DF : 192 - 223
@@ -134,7 +134,7 @@ void forward_page()
     while (0 < curbp->b_row--)
         down();
     /* this stops a reframe in display(), and epage is recalculated during display() */
-    curbp->b_epage = pos(curbp, curbp->b_ebuf); 
+    curbp->b_epage = pos(curbp, curbp->b_ebuf);
 }
 
 void backward_page()
@@ -175,7 +175,7 @@ void insert()
     } else {
         the_char[0] = *input == '\r' ? '\n' : *input;
         the_char[1] = '\0'; /* null terminate */
-        *curbp->b_gap++ = the_char[0]; 
+        *curbp->b_gap++ = the_char[0];
         curbp->b_point = pos(curbp, curbp->b_egap);
         /* the point is set so that and undo will backspace over the char */
         add_undo(curbp, UNDO_T_INSERT, curbp->b_point, the_char, NULL);

--- a/command.c
+++ b/command.c
@@ -3,6 +3,7 @@
  * Derived from: Anthony's Editor January 93, (Public Domain 1991, 1993 by Anthony Howe)
  */
 
+#include <signal.h>
 #include "header.h"
 
 void beginning_of_buffer()
@@ -43,6 +44,11 @@ int yesno(int flag)
 void quit()
 {
     done = 1;
+}
+
+void suspend()
+{
+    raise(SIGTSTP);
 }
 
 void redraw()

--- a/docs/flisp.md
+++ b/docs/flisp.md
@@ -1,5 +1,54 @@
 # fLisp Manual
 
+Table of Contents
+
+[Introduction](#introduction)
+
+[Lisp](#lisp)
+
+[Notation Convention](#notation)
+
+[fLisp Interpreter](#interpreter)
+
+[Syntax](#syntax)
+
+[Objects and Data Types](#objects_and_data_types)
+
+[Environments, Functions, Evaluation](#evaluation)
+
+[Primitives](#primitives)
+
+1.  [Interpreter Operations](#interp_ops)
+2.  [Object Operations](#object_ops)
+3.  [String Operations](#string_ops)
+4.  [Arithmetic Operations](#arithmetic_ops)
+
+Editor Extension
+
+[Buffers](#buffers)
+
+1.  [Text manipulation](#text)
+2.  [Selection](#selection)
+3.  [Cursor Movement](#cursor)
+4.  [Buffer management](#buffer_management)
+
+[User Interaction](#ui)
+
+1.  [Window Handling"](#windows)
+2.  [Message Line](#message_line)
+3.  [Keyboard Handling](#keyboard)
+4.  [Programming and System Interaction](#programming_system)
+
+[Error Handling](#exceptions)
+
+[Embedding fLisp](#embedding)
+
+[Implementation Details](#implementation)
+
+1.  [Garbage Collection](#gc)
+2.  [Memory Usage](#memory)
+3.  [Future Directions](#future)
+
 ### Introduction
 
 > A designer knows he has achieved perfection not when there is nothing
@@ -19,18 +68,18 @@ and compacted by Georg Lehner in 2023.
 This is a reference manual. If you want to learn about Lisp programming
 use other resources eg.
 
-- The [Common Lisp](lisp-lang.org) web site,
-- [An Introduction to Programming in Emacs
-  Lisp](https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html)
-  or
-- [The Scheme Programming Language](https://www.scheme.org/).
+-   The [Common Lisp](lisp-lang.org) web site,
+-   [An Introduction to Programming in Emacs
+    Lisp](https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html)
+    or
+-   [The Scheme Programming Language](https://www.scheme.org/).
 
 ### Lisp
 
 #### Notation Convention
 
 *fLisp* fancies to converge toward Emacs Lisp. Function descriptions are
-annoted with a compatibility scale:
+annotated with a compatibility scale:
 
 <u>C</u>  
 Interface compatible, though probably less featureful.
@@ -48,9 +97,9 @@ Annotation is omitted if the function does not exist in Emacs Lisp.
 
 We use the following notation rule for the *fLisp* syntax:
 
-*name*  
+`name`  
 *name* is the name of a variable. In Markdown documents it is shown with
-guillements, like this `«name»`.
+guillemots, like this `«name»`.
 
 `[text]`  
 `text` can be given zero or one time.
@@ -63,10 +112,10 @@ A single space is used to denote an arbitrary sequence of whitespace.
 
 Notes:
 
-- *fLisp* does not use `[`square brackets`]` and double-dots `..` as
-  syntactical elements.
-- String and number notation and formating conventions are the same as
-  in the C language
+-   *fLisp* does not use `[`square brackets`]` and double-dots `..` as
+    syntactical elements.
+-   String and number notation and formatting conventions are the same
+    as in the C language
 
 #### fLisp Interpreter
 
@@ -84,10 +133,10 @@ behave the same as core functions.
 
 #### Syntax
 
-Program text is written as a sequence of symbolic expressions -
-<span class="dfn">sexp</span>'s - in parenthesized form. A sexp is
-either a single object or a function invocation enclosed in parens.
-Function invocations can be infinitely nested.
+Program text is written as a sequence of symbolic expressions - <span
+class="dfn">sexp</span>'s - in parenthesized form. A sexp is either a
+single object or a function invocation enclosed in parens. Function
+invocations can be infinitely nested.
 
 The following characters are special to the reader:
 
@@ -103,21 +152,21 @@ Encloses strings.
 
 `'`  
 With a single quote prefix before a sexp, the sexp is expanded to
-`(quote «sexp»)` before it is evaluated.
+`(quote sexp)` before it is evaluated.
 
 `.`  
-The expresion` («a» . «b»)` evaluates to a *cons* object, holding the
+The expression` (a . b)` evaluates to a *cons* object, holding the
 objects *a* and *b*.
 
 Numbers are represented in decimal notation.
 
 A list of objects has the form:
 
-> `([«element» ..])`
+> `([element ..])`
 
 A function invocation has the form:
 
-> `(«name» [«param» ..])`
+> `(name [param ..])`
 
 There are two predefined objects. Their symbols are:
 
@@ -152,7 +201,7 @@ anonymous function with parameter evaluation
 <span class="dfn">macro</span>  
 anonymous function without parameter evaluation
 
-Objects are unmutable, functions either create new objects or return
+Objects are immutable, functions either create new objects or return
 existing ones.
 
 Characters do not have their own type. A single character is represented
@@ -160,12 +209,12 @@ by a *string* with length one.
 
 #### Environments, Functions, Evaluation
 
-All operations of the interpreter take place in an environment. An
-<span class="dfn">environment</span> is a collection of named objects.
-The object names are of type symbol. An object in an environment is said
-to be <span class="dfn">bound</span> to its name. Environments can have
-a parent. Each *fLisp* interpreter starts with a
-<span class="dfn">root</span> environment without a parent.
+All operations of the interpreter take place in an environment. An <span
+class="dfn">environment</span> is a collection of named objects. The
+object names are of type symbol. An object in an environment is said to
+be <span class="dfn">bound</span> to its name. Environments can have a
+parent. Each *fLisp* interpreter starts with a <span
+class="dfn">root</span> environment without a parent.
 
 lambda and macro objects are functions. They have a parameter list and a
 sexp as body. When functions are invoked a new environment is created as
@@ -185,158 +234,157 @@ current environment, and then recursively in the environments from which
 the lambda or macro was invoked. The symbol of the first found binding
 is then replaced by its object.
 
-*fLisp* counts with a set of built-in functions called
-<span class="dfn">primitives</span>. They are grouped in the manual by
-the type of objects they operate on. The primitives are bound in the
-global environment to the names under which they are described.
+*fLisp* counts with a set of built-in functions called <span
+class="dfn">primitives</span>. They are grouped in the manual by the
+type of objects they operate on. The primitives are bound in the global
+environment to the names under which they are described.
 
 #### Primitives
 
 ##### Interpreter Operations
 
-`(progn[ «expr»..])`  
+`(progn[ expr..])`  
 Each *expr* is evaluated, the value of the last is returned. If no
 *expr* is given, `progn` returns `nil`.
 
-`(cond[ «clause»..])`  
-Each *clause* is of the form `(«pred»[ «action»])`. `cond` evaluates
-each *clause* in turn. If *pred* evaluates to `nil`, the next *clause*
-is tested. If *pred* evaluates not to `nil` and if there is no *action*
-the value of *pred* is returned, otherwise `(progn «action»)` is
-returned and no more *clause*s are evaluated.
+`(cond[ clause..])`  
+Each *clause* is of the form `(pred[ action])`. `cond` evaluates each
+*clause* in turn. If *pred* evaluates to `nil`, the next *clause* is
+tested. If *pred* evaluates not to `nil` and if there is no *action* the
+value of *pred* is returned, otherwise `(progn action)` is returned and
+no more *clause*s are evaluated.
 
-`(setq «symbol» «value»[ «symbol» «value»..])`  
+`(setq symbol value[ symbol value..])`  
 Create or update named objects: If *symbol* is the name of an existing
 named object in the current or a parent environment the named object is
 set to *value*, if no symbol with this name exists, a new one is created
 in the current environment. `setq` returns the last *value*.
 
-`(lambda «params» «body»)`  
+`(lambda params body)`  
 Returns a *lambda* function which accepts 0 or more arguments, which are
 passed as list in the parameter *params*.
 
-`(lambda ([«param» ..]) «body»)`  
+`(lambda ([param ..]) body)`  
 Returns a *lambda* function which accepts the exact number of arguments
 given in the list of *param*s.
 
-`(lambda («param»[ «param»..] . «opt») «body»)`  
+`(lambda (param[ param..] . opt) body)`  
 Returns a *lambda* function which requires at least the exact number of
 arguments given in the list of *param*s. All extra arguments are passed
 as a list in the parameter *opt*.
 
-`(macro «params» «body»)`  
-`(macro ([«param» ..]) «body»)`  
-`(macro («param»[ «param»<..] . «opt») «body»)`  
+`(macro params body)`  
+`(macro ([param ..]) body)`  
+`(macro (param[ param<..] . opt) body)`  
 These forms return a macro function. Parameter handling is the same as
 with lambda.
 
-`(quote «expr»)`  
+`(quote expr)`  
 Returns *expr* without evaluating it.
 
-`(signal «symbol» «list»)`  
-tbd
-
-`(trap «list»)`  
-tbd
+`(signal type list)`  
+Throws an exception, stopping any further evaluation. Exceptions can be
+typed via the symbol *type* and must contain a list of exception related
+objects. `(signal 'error 'nil)` is probably the simplest signal.
 
 ##### Object Operations
 
-`(null «object»)`  
+`(null object)`  
 Returns `t` if *object* is `nil`, otherwise `nil`.
 
-`(symbolp «object»)`  
+`(symbolp object)`  
 Returns `t` if *object* is of type symbol, otherwise `nil`.
 
-`(symbol-name «object»)`  
+`(symbol-name object)`  
 If *object* is of type symbol return its value as string.
 
-`(numberp «object»)`  
+`(numberp object)`  
 Returns `t` if *object* is of type number, otherwise `nil`.
 
-`(stringp «object»)`  
+`(stringp object)`  
 Returns `t` if *object* is of type string, otherwise `nil`.
 
-`(consp «object»)`  
+`(consp object)`  
 Returns `t` if *object* is of type cons, otherwise `nil`.
 
-`(cons «car» «cdr»)`  
+`(cons car cdr)`  
 Returns a new cons with the first object set to the value of *car* and
 the second to the value of *cdr*.
 
-`(car «cons»)`  
+`(car cons)`  
 Returns the first object of *cons*.
 
-`(cdr «cons»)`  
+`(cdr cons)`  
 Returns the second object of *cons*.
 
-`(eq «a» «b»)`  
+`(eq a b)`  
 Returns `t` if *a* and *b* evaluate to the same object, `nil` otherwise.
 
-`(print «object»)`  
+`(print object)`  
 Formats *object* into a string which can be read by the reader and
 returns it. As a side effect, the string is printed to the output stream
 with a leading and a closing newline. `print` escapes quotes in strings
 with a backslash.
 
-`(princ «object»)`  
+`(princ object)`  
 Formats *object* into a string and returns it, As a side effect, the
 string is printed to the output stream.
 
 ##### String Operations
 
-`(string.length «string»)`  
+`(string.length string)`  
 Returns the length of *string* as a *number*.
 
-`(string.substring «string» «start» «end»)`  
-Returns the substring from *string* which starts with the character at
+`(string.substring string start end)`  
+Returns the sub string from *string* which starts with the character at
 index *start* and ends with index *end*. String indexes are zero based.
 
-`(string.append «string1» «string2»)`  
+`(string.append string1 string2)`  
 Returns a new string consisting of the concatenation of *string1* with
 *string2*.
 
-`(string-to-number «string»)`  
+`(string-to-number string)`  
 Converts *string* into a corresponding *number* object. String is
 interpreted as decimal based integer.
 
-`(number-to-string «number»)`  
+`(number-to-string number)`  
 Converts *number* into a *string* object.
 
-`(ascii «number»)`  
+`(ascii number)`  
 Converts *number* into a *string* with one character, which corresponds
 to the ASCII representation of *number*.
 
-`(ascii->number «string»)`  
+`(ascii->number string)`  
 Converts the first character of *string* into a *number* which
 corresponds to its ASCII value.
 
 ##### Arithmetic Operations
 
-`(+[ «arg»..])`  
+`(+[ arg..])`  
 Returns the sum of all *arg*s or `0` if none is given.
 
-`(*[ «arg»..])`  
+`(*[ arg..])`  
 Returns the product of all *arg*s or `1` if none given.
 
-`(-[ «arg»..])`  
+`(-[ arg..])`  
 Returns 0 if no *arg* is given, -*arg* if only one is given, *arg* minus
 the sum of all others otherwise.
 
-`(/ «arg»[ «div»..])`  
+`(/ arg[ div..])`  
 Returns 1/*arg* if no *div* is given, *arg*/*div*\[/*div*..\] if one or
 more *div*s are given, `inf` if one of the *div*s is `0` and the sum of
 the signs of all operands is even, `-inf` if it is odd.
 
-`(% «arg»[ «div»..])`  
+`(% arg[ div..])`  
 Returns `1` if no *div* is given, *arg*%*div*\[%*div*..\] if one or more
-*div*s are given. If one of the divs is `0`, the program exits with an
+*div*s are given. If one of the *div*s is `0`, the program exits with an
 arithmetic exception.
 
-`(= «arg»[ «arg»..])`  
-`(< «arg»[ «arg»..])`  
-`(> «arg»[ «arg»..])`  
-`(<= «arg»[ «arg»..])`  
-`(>= «arg»[ «arg»..])`  
+`(= arg[ arg..])`  
+`(< arg[ arg..])`  
+`(> arg[ arg..])`  
+`(<= arg[ arg..])`  
+`(>= arg[ arg..])`  
 These predicate functions apply the respective comparison operator
 between all *arg*s and return the respective result as `t` or `nil`. If
 only one *arg* is given they all return `t`.
@@ -345,12 +393,12 @@ only one *arg* is given they all return `t`.
 
 The editor extensions introduces several types of objects/functionality:
 
-- <span class="dfn">Buffers</span> hold text
-- <span class="dfn">Windows</span> display buffer contents to the user
-- <span class="dfn">Keyboard Input</span> allows the user to interact
-  with buffers and windows
-- The <span class="dfn">Message Line</span> gives feedback to the user
-- Several other function for operating system or user interaction
+-   <span class="dfn">Buffers</span> hold text
+-   <span class="dfn">Windows</span> display buffer contents to the user
+-   <span class="dfn">Keyboard Input</span> allows the user to interact
+    with buffers and windows
+-   The <span class="dfn">Message Line</span> gives feedback to the user
+-   Several other function for operating system or user interaction
 
 #### Buffers
 
@@ -359,7 +407,7 @@ fLisp. The description is separated in function related to buffer
 management and text manipulation. Text manipulation always operates on
 the <span class="dfn">current buffer</span>. Buffer management creates,
 deletes buffers, or selects one of the existing buffers as the current
-buffer. current buffercode.
+buffer.
 
 Buffers store text and allow to manipulate it. A buffer has the
 following properties:
@@ -376,29 +424,29 @@ The position in the text where text manipulation takes place.
 
 *mark*  
 An optional second position in the text. If the *mark* is set, the text
-between *point* and *mark* is called the
-<span class="dfn">selection</span> or <span class="dfn">region</span>.
+between *point* and *mark* is called the <span
+class="dfn">selection</span> or <span class="dfn">region</span>.
 
 *filename*  
 If set the buffer is associated with the respective file.
 
 *flags*  
-Different flags determine the behaviour of the buffer.
+Different flags determine the behavior of the buffer.
 
 In the following, all mentions of these variables refer to the current
 buffers properties.
 
 ##### Text manipulation
 
-`(insert-string «string»)`  
+`(insert-string string)`  
 Inserts *string* at *point*. <u>S: insert</u>.
 
-`(insert-file-contents-literally «string» `\[*flag*\]`)`  
+`(insert-file-contents-literally string `\[`flag`\]`)`  
 Inserts the file *string* after *point*. If *flag* is not nil the buffer
 is marked as not modified. <u>B</u>
 
 Note: Currently the flag is forced to nil. The function should return
-`(«filename» «count»)` but it returns a flag indicating if the operation
+`(filename count)` but it returns a flag indicating if the operation
 succeeded.
 
 `(erase-buffer)`  
@@ -439,8 +487,8 @@ Returns the position of *point*. <u>S: point</u>
 Returns the maximum accessible value of point in the current buffer.
 <u>S: point-max</u>
 
-`(set-clipboard «variable»)`  
-`Sets «clipboard» to the contents of «variable».` <u>S:
+`(set-clipboard variable)`  
+`Sets clipboard to the contents of variable.` <u>S:
 gui-set-selection</u>
 
 `(get-clipboard)`  
@@ -448,21 +496,21 @@ Returns the *clipboard* contents. <u>S: gui-get-selection</u>
 
 ##### Cursor Movement
 
-`(set-point «number»)`  
+`(set-point number)`  
 Sets the point to in the current buffer to the position *number*. <u>S:
 goto-char</u>
 
-`(goto-line «number»)`  
+`(goto-line number)`  
 Sets the point in the current buffer to the first character on line
 *number*. <u>S: goto-line</u>, not an Elisp function.
 
-`(search-forward «string»)`  
+`(search-forward string)`  
 Searches for *string* in the current buffer, starting from point
 forward. If string is found, sets the point after the first occurrence
 of *string* and returns `t`, otherwise leaves point alone and returns
 `nil`. <u>D</u>
 
-`(search-backward «string»)`  
+`(search-backward string)`  
 Searches for *string* in the current buffer, starting from point
 backwards. If string is found, sets the point before the first
 occurrence of *string* and returns `t`, otherwise leaves point alone and
@@ -514,7 +562,7 @@ it as the first line. <u>S: scroll-up</u>
 
 `(backward-page)`  
 Moves the point of the current buffer to the beginning of the first
-visible line of the associoated screen and scrolls the screen down to
+visible line of the associated screen and scrolls the screen down to
 show it as the last line. <u>S: scroll-down</u>
 
 `(next-line)`  
@@ -538,28 +586,28 @@ Lists all the buffers in a buffer called `*buffers*`.
 Returns the number of buffers, includes all special buffers and
 `*buffers*`.
 
-`(select-buffer «string»)`  
+`(select-buffer string)`  
 Makes the buffer named *string* the current buffer. Note: <u>C</u> to
 `set-buffer` in Elisp.
 
-`(rename-buffer «string»)`  
+`(rename-buffer string)`  
 Rename the current buffer to *string*. <u>C</u>
 
-`(kill-buffer «string»)`  
+`(kill-buffer string)`  
 Kill the buffer names *string*. Unsaved changes are discarded. <u>C</u>
 
 `(get-buffer-name)`  
 Return the name of the current buffer. Note: <u>C</u> to `buffer-name`
 in Elisp.
 
-`(add-mode-global «string»)`  
+`(add-mode-global string)`  
 Sets global mode *string* for all buffers. Currently the only global
 mode is <span class="kbd">undo</span>.
 
-`(find-file «string»)`  
+`(find-file string)`  
 Loads file with path string into a new buffer. <u>C</u>
 
-`(save-buffer «string»)`  
+`(save-buffer string)`  
 Saves the buffer named *string* to disk. <u>C</u>
 
 #### User Interaction
@@ -592,29 +640,29 @@ Updates all windows by marking them modified and calling
 
 ##### Message Line
 
-`(message «string»)`  
+`(message string)`  
 Displays *string* in the message line. <u>D</u>
 
 `(clear-message-line)`  
 Displays the empty string in the message line.
 
-`(prompt «prompt» «default»)`  
+`(prompt prompt default)`  
 Displays *prompt* in the command line and sets *default* as initial
-value for the user respones. The user can edit the response. When
+value for the user response. The user can edit the response. When
 hitting return, the final response is returned.
 
-`(show-prompt «prompt» «default»)`  
-Displays *prompt* and *default* in the commandline, but does not allow
+`(show-prompt prompt default)`  
+Displays *prompt* and *default* in the command line, but does not allow
 editing. Returns `t`.
 
-`(prompt-filename «prompt»)`  
-Displays *prompt* in the commandline and allows to enter or search for a
-file name. Returns the relative path to the selected file name or the
+`(prompt-filename prompt)`  
+Displays *prompt* in the command line and allows to enter or search for
+a file name. Returns the relative path to the selected file name or the
 response typed by the user.
 
 ##### Keyboard Handling
 
-`(set-key «key-name» «lisp-func»)`  
+`(set-key key-name lisp-func)`  
 Binds key key-name to the lisp function *lisp-func*.
 
 `(get-key-name)`  
@@ -651,23 +699,162 @@ Evaluates the *region* in the current buffer, inserts the result at
 *point*. If *point* is before *mark* `eval-block` does nothing but
 returning `t`.
 
-`(system «string»)`  
+`(system string)`  
 Executes the
 [system(1)](https://man7.org/linux/man-pages/man3/system.3.html)
 function with *string* as parameter.
 
-`(os.getenv «string») `  
+`(os.getenv string) `  
 Returns the value of the environment variable named *string*.
 
-`(log-message «string»)`  
+`(log-message string)`  
 Logs *string* to the `*messages*` buffer.
 
-`(log-debug «string»)`  
+`(log-debug string)`  
 Logs string to the file `debug.out`.
 
 `(get-version-string)`  
 Returns the complete version string of Femto, including the copyright.
 
+### Error handling
+
+Whenever fLisp encounters an error an exception is thrown. Exceptions
+have a non-zero result code and an error message. The error message is a
+string containing the serialization of the object causing the error — if
+any — and an individual user readable string.
+
+fLisp does not implement stack backtracking. exceptions are only caught
+on the top level of an evaluation.
+
+Exceptions can be thrown in Lisp code via the [`signal`](#interp_ops)
+function.
+
+<span class="mark">Note: currently the error result code is always 1. It
+is planned to distinguish different error classes, e.g. parsing errors,
+execution errors, I/O errors, input errors, … </span>
+
+### Embedding fLisp
+
+fLisp exposes the following public interfaces:
+
+`Interpreter *lisp_init(int argc, char **argv, char       *library_path)`  
+`lisp_init()` creates and initializes an fLisp interpreter. The initial
+environment contains the following symbols:
+
+*argv0*  
+The string stored in `*argv[0]`, if any
+
+*argv*  
+The list of strings stored in `argv`
+
+*script_dir*  
+The string stored in `library_path`
+
+A pointer to an *Interpreter* struct is returned, which is used to
+operate the interpreter.
+
+`ResultCode lisp_eval(interp, format, …)`  
+Evaluates input in the fLisp interpreter *interp*. The input is
+generated the same way as in `printf()` from the *format* string and any
+following optional arguments.
+
+The *ResultCode* is `0` when the input is evaluated successfully and
+non-zero if any error occurred during evaluation. The result code is
+also stored in *interp-\>result*.
+
+After evaluation *interp-\>output* contains the output of the evaluation
+and *interp-\>message* contains the error message if result code is
+non-zero.
+
+<span class="mark">Note: currently only one interpreter can be
+created.</span>
+
 ### Implementation Details
 
-<span class="mark">Tbd.: Memory consumption, limits, hacking, ...</span>
+#### Garbage Collection
+
+fLisp implements Cheney's copying garbage collector, with which memory
+is divided into two equal halves (semi spaces): from- and to-space.
+From-space is where new objects are allocated, whereas to-space is used
+during garbage collection.
+
+When garbage collection is performed, objects that are still in use
+(live) are copied from from-space to to-space. To-space then becomes the
+new from-space and vice versa, thereby discarding all objects that have
+not been copied.
+
+Our garbage collector takes as input a list of root objects. Objects
+that can be reached by recursively traversing this list are considered
+live and will be moved to to-space. When we move an object, we must also
+update its pointer within the list to point to the objects new location
+in memory.
+
+However, this implies that our interpreter cannot use raw pointers to
+objects in any function that might trigger garbage collection (or risk
+causing a SEGV when accessing an object that has been moved). Instead,
+objects must be added to the list and then only accessed through the
+pointer inside the list.
+
+Thus, whenever we would have used a raw pointer to an object, we use a
+pointer to the pointer inside the list instead:
+
+    function:              pointer to pointer inside list (Object **)
+                                   |
+                                   v
+    list of root objects:  pointer to object (Object *)
+                                   |
+                                   v
+    semi space:             object in memory
+        
+
+`GC_ROOTS` and `GC_PARAM` are used to pass the list from function to
+function.
+
+`GC_TRACE` adds an object to the list and declares a variable which
+points to the objects pointer inside the list.
+
+`GC_TRACE(gcX, X)`: add object *X* to the list and declare
+`Object **gcX` to point to the pointer to *X* inside the list.
+
+#### Memory Usage
+
+Some compile time adjustable limits in `lisp.h`:
+
+Object memory  
+4M, `FLISP_MEMORY_SIZE`.
+
+Input buffer  
+2048, `INPUT_FMT_BUFSIZ`, size of the formatting buffer for
+`lisp_eval()`.
+
+Output buffer  
+2048, `WRITE_FMT_BUFSIZ`, size of the output and message formatting
+buffer.
+
+fLisp can live with much less object memory, but the “OXO” game requires
+a lot and <span class="mark">the garbage collector has a bug</span>
+which makes OXO segfault.
+
+#### Future Directions
+
+fLisp could be made completely independent of Femto, thus making the
+interpreter embeddable in any application. The `debug()` function is
+still borrowed from `main.c` and it has to be devised how to extend the
+interpreter dynamically; the editor extensions are currently compiled
+into the interpreter.
+
+Integer arithmetic would be sufficient for all current purposes and
+increase portability, speed while reducing size.
+
+The internally used “Stream” abstraction for reading Lisp input and
+writing output is incomplete and complicated. An alternative would be to
+use only string input and output. File input can be read as a whole into
+memory and use the string input processing. This would also have
+consequences for the Lisp reader and probably simplify implementation of
+improved error reporting, a lá line/char offset reporting. The downside
+is, that this would remove support for `stdin`/`stdout` reading/writing.
+
+Exception handling should be improved by returning differentiated error
+codes. One of the benefits would be the possibility to implement
+externally an interactive repl with `stdin`/`stdout` streams, by reading
+and eval'ing until no more “incomplete input” result codes are returned.

--- a/docs/flisp.md
+++ b/docs/flisp.md
@@ -248,11 +248,11 @@ Each *expr* is evaluated, the value of the last is returned. If no
 *expr* is given, `progn` returns `nil`.
 
 `(cond[ clause..])`  
-Each *clause* is of the form `(pred[ action])`. `cond` evaluates each
+Each *clause* is of the form `(pred[ action ..])`. `cond` evaluates each
 *clause* in turn. If *pred* evaluates to `nil`, the next *clause* is
 tested. If *pred* evaluates not to `nil` and if there is no *action* the
-value of *pred* is returned, otherwise `(progn action)` is returned and
-no more *clause*s are evaluated.
+value of *pred* is returned, otherwise `(progn action ..)` is returned
+and no more *clause*s are evaluated.
 
 `(setq symbol value[ symbol value..])`  
 Create or update named objects: If *symbol* is the name of an existing
@@ -417,10 +417,11 @@ Buffers are identified by their name. If a buffer name is enclosed in
 `*`asterisks`*` the buffer receives special treatment.
 
 *text*  
-0 or more characters.
+zero or more characters.
 
 *point*  
-The position in the text where text manipulation takes place.
+The position in the text where text manipulation takes place. The first
+position in the text is 0. Note: in Emacs the first position is 1.
 
 *mark*  
 An optional second position in the text. If the *mark* is set, the text
@@ -439,7 +440,7 @@ buffers properties.
 ##### Text manipulation
 
 `(insert-string string)`  
-Inserts *string* at *point*. <u>S: insert</u>.
+Inserts *string* before *point*. <u>S: insert</u>.
 
 `(insert-file-contents-literally string `\[`flag`\]`)`  
 Inserts the file *string* after *point*. If *flag* is not nil the buffer
@@ -460,7 +461,7 @@ Deletes the character to the left of *point*. <u>S:
 delete-backward-char</u>
 
 `(get-char)`  
-Returns the character to the left of *point*. <u>S: get-byte</u>
+Returns the character at *point*. <u>S: get-byte</u>
 
 `(copy-region)`  
 Copies *region* to the *clipboard*. <u>S: copy-region-as-kill</u>

--- a/docs/flisp.md
+++ b/docs/flisp.md
@@ -58,7 +58,7 @@ Editor Extension
 
 *fLisp* is a tiny yet practical interpreter for a dialect of the Lisp
 programming language. It is used as extension language for the
-[Femto](https://github.com/matp/tiny-lisp) text editor.
+[Femto](https://github.com/hughbarney/femto) text editor.
 
 *fLisp* originates from [Tiny-Lisp by
 matp](https://github.com/matp/tiny-lisp) (pre 2014), was integrated into
@@ -68,7 +68,7 @@ and compacted by Georg Lehner in 2023.
 This is a reference manual. If you want to learn about Lisp programming
 use other resources eg.
 
--   The [Common Lisp](lisp-lang.org) web site,
+-   The [Common Lisp](https://lisp-lang.org) web site,
 -   [An Introduction to Programming in Emacs
     Lisp](https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html)
     or

--- a/docs/flisp.md
+++ b/docs/flisp.md
@@ -1,0 +1,673 @@
+# fLisp Manual
+
+### Introduction
+
+> A designer knows he has achieved perfection not when there is nothing
+> left to add, but when there is nothing left to take away.
+>
+> — Antoine de Saint-Exupery
+
+*fLisp* is a tiny yet practical interpreter for a dialect of the Lisp
+programming language. It is used as extension language for the
+[Femto](https://github.com/matp/tiny-lisp) text editor.
+
+*fLisp* originates from [Tiny-Lisp by
+matp](https://github.com/matp/tiny-lisp) (pre 2014), was integrated into
+[Femto](https://github.com/hughbarney/femto) by Hugh Barnes (pre 2016)
+and compacted by Georg Lehner in 2023.
+
+This is a reference manual. If you want to learn about Lisp programming
+use other resources eg.
+
+- The [Common Lisp](lisp-lang.org) web site,
+- [An Introduction to Programming in Emacs
+  Lisp](https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html)
+  or
+- [The Scheme Programming Language](https://www.scheme.org/).
+
+### Lisp
+
+#### Notation Convention
+
+*fLisp* fancies to converge toward Emacs Lisp. Function descriptions are
+annoted with a compatibility scale:
+
+<u>C</u>  
+Interface compatible, though probably less featureful.
+
+<u>D</u>  
+Same name, but different behavior.
+
+<u>S: *name*</u>  
+*name* is a similar but not compatible function in Emacs Lisp.
+
+<u>B</u>  
+Buggy/incompatible implementation.
+
+Annotation is omitted if the function does not exist in Emacs Lisp.
+
+We use the following notation rule for the *fLisp* syntax:
+
+*name*  
+*name* is the name of a variable. In Markdown documents it is shown with
+guillements, like this `«name»`.
+
+`[text]`  
+`text` can be given zero or one time.
+
+`[text..]`  
+`text` can be given zero or more times.
+
+“` `”  
+A single space is used to denote an arbitrary sequence of whitespace.
+
+Notes:
+
+- *fLisp* does not use `[`square brackets`]` and double-dots `..` as
+  syntactical elements.
+- String and number notation and formating conventions are the same as
+  in the C language
+
+#### fLisp Interpreter
+
+When *fLisp* is invoked it follows a three step process:
+
+1.  Read: program text is read in and converted into an internal
+    representation.
+2.  Evaluate: the internal representation is evaluated
+3.  Print: the result of the evaluation is returned to the invoker.
+
+Core functions of the language operate on built-in objects only. *fLisp*
+is extended with additional functions in order to interact with editor
+related objects. With respect to the interpreter, extension functions
+behave the same as core functions.
+
+#### Syntax
+
+Program text is written as a sequence of symbolic expressions -
+<span class="dfn">sexp</span>'s - in parenthesized form. A sexp is
+either a single object or a function invocation enclosed in parens.
+Function invocations can be infinitely nested.
+
+The following characters are special to the reader:
+
+`(`  
+Starts a function invocation, *list* or *cons* object (see [Objects and
+Data Types](#objects_and_data_types)).
+
+`)`  
+Finishes a function invocation, *list* or *cons* object
+
+`"`  
+Encloses strings.
+
+`'`  
+With a single quote prefix before a sexp, the sexp is expanded to
+`(quote «sexp»)` before it is evaluated.
+
+`.`  
+The expresion` («a» . «b»)` evaluates to a *cons* object, holding the
+objects *a* and *b*.
+
+Numbers are represented in decimal notation.
+
+A list of objects has the form:
+
+> `([«element» ..])`
+
+A function invocation has the form:
+
+> `(«name» [«param» ..])`
+
+There are two predefined objects. Their symbols are:
+
+`nil`  
+represents: the empty list: `()`, the end of a list marker or the false
+value in logical operations.
+
+`t`  
+“true”, a predefined, non-false value.
+
+#### Objects and Data Types
+
+*fLisp* objects have exactly one of the following data types:
+
+<span class="dfn">number</span>  
+[double precision floating point
+number.](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)
+
+<span class="dfn">string</span>  
+character array.
+
+<span class="dfn">cons</span>  
+object holding two pointers to objects.
+
+<span class="dfn">symbol</span>  
+string with restricted character set:
+`[A-Z][0-9][a-z]!#$%&*+-./:<=>?@^_~`
+
+<span class="dfn">lambda</span>  
+anonymous function with parameter evaluation
+
+<span class="dfn">macro</span>  
+anonymous function without parameter evaluation
+
+Objects are unmutable, functions either create new objects or return
+existing ones.
+
+Characters do not have their own type. A single character is represented
+by a *string* with length one.
+
+#### Environments, Functions, Evaluation
+
+All operations of the interpreter take place in an environment. An
+<span class="dfn">environment</span> is a collection of named objects.
+The object names are of type symbol. An object in an environment is said
+to be <span class="dfn">bound</span> to its name. Environments can have
+a parent. Each *fLisp* interpreter starts with a
+<span class="dfn">root</span> environment without a parent.
+
+lambda and macro objects are functions. They have a parameter list and a
+sexp as body. When functions are invoked a new environment is created as
+child of the current environment. Functions receive zero or more objects
+from the caller. These are bound one by one to the symbols in the
+parameter list in the new environment.
+
+lambdas return the result of evaluating the body in the new environment.
+
+macros first evaluate the body in the calling environment. The resulting
+sexp is evaluated in the new environment and that result is returned.
+macro bodies are typically crafted to return new sexp's in terms of the
+parameters.
+
+When a sexp is evaluated and encounters a symbol it looks it up in the
+current environment, and then recursively in the environments from which
+the lambda or macro was invoked. The symbol of the first found binding
+is then replaced by its object.
+
+*fLisp* counts with a set of built-in functions called
+<span class="dfn">primitives</span>. They are grouped in the manual by
+the type of objects they operate on. The primitives are bound in the
+global environment to the names under which they are described.
+
+#### Primitives
+
+##### Interpreter Operations
+
+`(progn[ «expr»..])`  
+Each *expr* is evaluated, the value of the last is returned. If no
+*expr* is given, `progn` returns `nil`.
+
+`(cond[ «clause»..])`  
+Each *clause* is of the form `(«pred»[ «action»])`. `cond` evaluates
+each *clause* in turn. If *pred* evaluates to `nil`, the next *clause*
+is tested. If *pred* evaluates not to `nil` and if there is no *action*
+the value of *pred* is returned, otherwise `(progn «action»)` is
+returned and no more *clause*s are evaluated.
+
+`(setq «symbol» «value»[ «symbol» «value»..])`  
+Create or update named objects: If *symbol* is the name of an existing
+named object in the current or a parent environment the named object is
+set to *value*, if no symbol with this name exists, a new one is created
+in the current environment. `setq` returns the last *value*.
+
+`(lambda «params» «body»)`  
+Returns a *lambda* function which accepts 0 or more arguments, which are
+passed as list in the parameter *params*.
+
+`(lambda ([«param» ..]) «body»)`  
+Returns a *lambda* function which accepts the exact number of arguments
+given in the list of *param*s.
+
+`(lambda («param»[ «param»..] . «opt») «body»)`  
+Returns a *lambda* function which requires at least the exact number of
+arguments given in the list of *param*s. All extra arguments are passed
+as a list in the parameter *opt*.
+
+`(macro «params» «body»)`  
+`(macro ([«param» ..]) «body»)`  
+`(macro («param»[ «param»<..] . «opt») «body»)`  
+These forms return a macro function. Parameter handling is the same as
+with lambda.
+
+`(quote «expr»)`  
+Returns *expr* without evaluating it.
+
+`(signal «symbol» «list»)`  
+tbd
+
+`(trap «list»)`  
+tbd
+
+##### Object Operations
+
+`(null «object»)`  
+Returns `t` if *object* is `nil`, otherwise `nil`.
+
+`(symbolp «object»)`  
+Returns `t` if *object* is of type symbol, otherwise `nil`.
+
+`(symbol-name «object»)`  
+If *object* is of type symbol return its value as string.
+
+`(numberp «object»)`  
+Returns `t` if *object* is of type number, otherwise `nil`.
+
+`(stringp «object»)`  
+Returns `t` if *object* is of type string, otherwise `nil`.
+
+`(consp «object»)`  
+Returns `t` if *object* is of type cons, otherwise `nil`.
+
+`(cons «car» «cdr»)`  
+Returns a new cons with the first object set to the value of *car* and
+the second to the value of *cdr*.
+
+`(car «cons»)`  
+Returns the first object of *cons*.
+
+`(cdr «cons»)`  
+Returns the second object of *cons*.
+
+`(eq «a» «b»)`  
+Returns `t` if *a* and *b* evaluate to the same object, `nil` otherwise.
+
+`(print «object»)`  
+Formats *object* into a string which can be read by the reader and
+returns it. As a side effect, the string is printed to the output stream
+with a leading and a closing newline. `print` escapes quotes in strings
+with a backslash.
+
+`(princ «object»)`  
+Formats *object* into a string and returns it, As a side effect, the
+string is printed to the output stream.
+
+##### String Operations
+
+`(string.length «string»)`  
+Returns the length of *string* as a *number*.
+
+`(string.substring «string» «start» «end»)`  
+Returns the substring from *string* which starts with the character at
+index *start* and ends with index *end*. String indexes are zero based.
+
+`(string.append «string1» «string2»)`  
+Returns a new string consisting of the concatenation of *string1* with
+*string2*.
+
+`(string-to-number «string»)`  
+Converts *string* into a corresponding *number* object. String is
+interpreted as decimal based integer.
+
+`(number-to-string «number»)`  
+Converts *number* into a *string* object.
+
+`(ascii «number»)`  
+Converts *number* into a *string* with one character, which corresponds
+to the ASCII representation of *number*.
+
+`(ascii->number «string»)`  
+Converts the first character of *string* into a *number* which
+corresponds to its ASCII value.
+
+##### Arithmetic Operations
+
+`(+[ «arg»..])`  
+Returns the sum of all *arg*s or `0` if none is given.
+
+`(*[ «arg»..])`  
+Returns the product of all *arg*s or `1` if none given.
+
+`(-[ «arg»..])`  
+Returns 0 if no *arg* is given, -*arg* if only one is given, *arg* minus
+the sum of all others otherwise.
+
+`(/ «arg»[ «div»..])`  
+Returns 1/*arg* if no *div* is given, *arg*/*div*\[/*div*..\] if one or
+more *div*s are given, `inf` if one of the *div*s is `0` and the sum of
+the signs of all operands is even, `-inf` if it is odd.
+
+`(% «arg»[ «div»..])`  
+Returns `1` if no *div* is given, *arg*%*div*\[%*div*..\] if one or more
+*div*s are given. If one of the divs is `0`, the program exits with an
+arithmetic exception.
+
+`(= «arg»[ «arg»..])`  
+`(< «arg»[ «arg»..])`  
+`(> «arg»[ «arg»..])`  
+`(<= «arg»[ «arg»..])`  
+`(>= «arg»[ «arg»..])`  
+These predicate functions apply the respective comparison operator
+between all *arg*s and return the respective result as `t` or `nil`. If
+only one *arg* is given they all return `t`.
+
+### Editor Extension
+
+The editor extensions introduces several types of objects/functionality:
+
+- <span class="dfn">Buffers</span> hold text
+- <span class="dfn">Windows</span> display buffer contents to the user
+- <span class="dfn">Keyboard Input</span> allows the user to interact
+  with buffers and windows
+- The <span class="dfn">Message Line</span> gives feedback to the user
+- Several other function for operating system or user interaction
+
+#### Buffers
+
+This section describes the buffer related functions added by Femto to
+fLisp. The description is separated in function related to buffer
+management and text manipulation. Text manipulation always operates on
+the <span class="dfn">current buffer</span>. Buffer management creates,
+deletes buffers, or selects one of the existing buffers as the current
+buffer. current buffercode.
+
+Buffers store text and allow to manipulate it. A buffer has the
+following properties:
+
+*name*  
+Buffers are identified by their name. If a buffer name is enclosed in
+`*`asterisks`*` the buffer receives special treatment.
+
+*text*  
+0 or more characters.
+
+*point*  
+The position in the text where text manipulation takes place.
+
+*mark*  
+An optional second position in the text. If the *mark* is set, the text
+between *point* and *mark* is called the
+<span class="dfn">selection</span> or <span class="dfn">region</span>.
+
+*filename*  
+If set the buffer is associated with the respective file.
+
+*flags*  
+Different flags determine the behaviour of the buffer.
+
+In the following, all mentions of these variables refer to the current
+buffers properties.
+
+##### Text manipulation
+
+`(insert-string «string»)`  
+Inserts *string* at *point*. <u>S: insert</u>.
+
+`(insert-file-contents-literally «string» `\[*flag*\]`)`  
+Inserts the file *string* after *point*. If *flag* is not nil the buffer
+is marked as not modified. <u>B</u>
+
+Note: Currently the flag is forced to nil. The function should return
+`(«filename» «count»)` but it returns a flag indicating if the operation
+succeeded.
+
+`(erase-buffer)`  
+Erases all text in the current buffer. <u>C</u>
+
+`(delete)`  
+Deletes the character after *point*. <u>S: delete-char</u>
+
+`(backspace)`  
+Deletes the character to the left of *point*. <u>S:
+delete-backward-char</u>
+
+`(get-char)`  
+Returns the character to the left of *point*. <u>S: get-byte</u>
+
+`(copy-region)`  
+Copies *region* to the *clipboard*. <u>S: copy-region-as-kill</u>
+
+`(kill-region)`  
+Deletes the text in the *region* and copies it to the *clipboard*.
+<u>D</u>
+
+`(yank)`  
+Pastes the *clipboard* before *point*. <u>C</u>
+
+##### Selection
+
+`(set-mark)`  
+Sets *mark* to *point*. <u>D</u>
+
+`(get-mark)`  
+Returns the position of *mark*, -1 if *mark* is unset. <u>S: mark</u>
+
+`(get-point)`  
+Returns the position of *point*. <u>S: point</u>
+
+`(get-point-max)`  
+Returns the maximum accessible value of point in the current buffer.
+<u>S: point-max</u>
+
+`(set-clipboard «variable»)`  
+`Sets «clipboard» to the contents of «variable».` <u>S:
+gui-set-selection</u>
+
+`(get-clipboard)`  
+Returns the *clipboard* contents. <u>S: gui-get-selection</u>
+
+##### Cursor Movement
+
+`(set-point «number»)`  
+Sets the point to in the current buffer to the position *number*. <u>S:
+goto-char</u>
+
+`(goto-line «number»)`  
+Sets the point in the current buffer to the first character on line
+*number*. <u>S: goto-line</u>, not an Elisp function.
+
+`(search-forward «string»)`  
+Searches for *string* in the current buffer, starting from point
+forward. If string is found, sets the point after the first occurrence
+of *string* and returns `t`, otherwise leaves point alone and returns
+`nil`. <u>D</u>
+
+`(search-backward «string»)`  
+Searches for *string* in the current buffer, starting from point
+backwards. If string is found, sets the point before the first
+occurrence of *string* and returns `t`, otherwise leaves point alone and
+returns `nil`. <u>D</u>
+
+`(beginning-of-buffer)`  
+Sets the point in the current buffer to the first buffer position,
+leaving mark in its current position. <u>C</u>
+
+`(end-of-buffer)`  
+Sets the point in the current buffer to the last buffer position,
+leaving mark in its current position. <u>C</u>
+
+`(beginning-of-line)`  
+Sets point before the first character of the current line, leaving mark
+in its current position. <u>S: move-beginning-of-line</u>
+
+`(end-of-line)`  
+Sets point after the last character of the current line, i.e. before the
+end-of-line character sequence, leaving mark in its current position.
+<u>S: move-end-of-line</u>
+
+`(forward-word)`  
+Moves the point in the current buffer forward before the first char of
+the next word. If there is no word left the point is set to the end of
+the buffer. If the point is already at the start or within a word, the
+current word is skipped. <u>D</u>: **Note**: Elisp moves to the *end* of
+the the next word.
+
+`(backward-word)`  
+Moves the point in the current buffer backward after the last char of
+the previous word. If there is no word left the point is set to the
+beginning of the buffer. If the point is already at the end or within a
+word, the current word is skipped. <u>D</u>: **Note**: Elisp moves to
+the *beginning* of the previous word.
+
+`(forward-char)`  
+Moves the point in the current buffer one character forward, but not
+past the end of the buffer. <u>C</u>
+
+`(backward-char)`  
+Moves the point in the current buffer one character backward, but not
+before the end of the buffer. <u>C</u>
+
+`(forward-page)`  
+Moves the point of the current buffer to the beginning of the last
+visible line of the associated screen and scrolls the screen up to show
+it as the first line. <u>S: scroll-up</u>
+
+`(backward-page)`  
+Moves the point of the current buffer to the beginning of the first
+visible line of the associoated screen and scrolls the screen down to
+show it as the last line. <u>S: scroll-down</u>
+
+`(next-line)`  
+Moves the point in the current buffer to the same character position in
+the next line, or to the end of the next line if there are not enough
+characters. In the last line of the buffer moves the point to the end of
+the buffer. <u>C</u>
+
+`(previous-line)`  
+Moves the point in the current buffer to the same character position in
+the previous line, or to the end of the previous line if there are not
+enough characters. In the first line of the buffer the point is not
+moved. <u>C</u>
+
+##### Buffer management
+
+`(list-buffers)`  
+Lists all the buffers in a buffer called `*buffers*`.
+
+`(get-buffer-count)`  
+Returns the number of buffers, includes all special buffers and
+`*buffers*`.
+
+`(select-buffer «string»)`  
+Makes the buffer named *string* the current buffer. Note: <u>C</u> to
+`set-buffer` in Elisp.
+
+`(rename-buffer «string»)`  
+Rename the current buffer to *string*. <u>C</u>
+
+`(kill-buffer «string»)`  
+Kill the buffer names *string*. Unsaved changes are discarded. <u>C</u>
+
+`(get-buffer-name)`  
+Return the name of the current buffer. Note: <u>C</u> to `buffer-name`
+in Elisp.
+
+`(add-mode-global «string»)`  
+Sets global mode *string* for all buffers. Currently the only global
+mode is <span class="kbd">undo</span>.
+
+`(find-file «string»)`  
+Loads file with path string into a new buffer. <u>C</u>
+
+`(save-buffer «string»)`  
+Saves the buffer named *string* to disk. <u>C</u>
+
+#### User Interaction
+
+This section lists function related to window and message line
+manipulation, keyboard input and system interaction.
+
+##### Window Handling
+
+`(delete-other-windows)`  
+Make current window the only window. <u>C</u>
+
+`(split-window)`  
+Splits the current window. Creates a new window for the current buffer.
+<u>C</u>
+
+`(other-window)`  
+Moves the cursor to the next window down on the screen. Makes the buffer
+in that window the current buffer. <u>D</u>
+
+Note: Elisp `other-window` has a required parameter *count*, which
+specifies the number of windows to move down or up.
+
+`(update-display)`  
+Updates all modified windows.
+
+`(refresh)`  
+Updates all windows by marking them modified and calling
+`update-display`.
+
+##### Message Line
+
+`(message «string»)`  
+Displays *string* in the message line. <u>D</u>
+
+`(clear-message-line)`  
+Displays the empty string in the message line.
+
+`(prompt «prompt» «default»)`  
+Displays *prompt* in the command line and sets *default* as initial
+value for the user respones. The user can edit the response. When
+hitting return, the final response is returned.
+
+`(show-prompt «prompt» «default»)`  
+Displays *prompt* and *default* in the commandline, but does not allow
+editing. Returns `t`.
+
+`(prompt-filename «prompt»)`  
+Displays *prompt* in the commandline and allows to enter or search for a
+file name. Returns the relative path to the selected file name or the
+response typed by the user.
+
+##### Keyboard Handling
+
+`(set-key «key-name» «lisp-func»)`  
+Binds key key-name to the lisp function *lisp-func*.
+
+`(get-key-name)`  
+Returns the name of the currently pressed key, eg: `c-k` for control-k.
+
+`(get-key-funcname)`  
+Return the name of the function bound to the currently pressed key.
+
+`(execute-key)`  
+Executes the function of the last bound key. <span class="mark">Tbd.
+bound or pressed?</span>
+
+`(describe-bindings)`  
+Creates a listing of all current key bindings, in a buffer named
+`*help*` and displays it in a new window. <u>C</u>
+
+`(describe-functions)`  
+Creates a listing of all functions bound to keys in a buffer named
+`*help*` and displays it in a new window.
+
+`(getch)`  
+Waits for a key to be pressed and returns the key as string. See also
+`get-key-name`, `get-key-funcname` and `execute-key`.
+
+##### Programming and System Interaction
+
+`(exit)`  
+Exit Femto without saving modified buffers.
+
+`(eval-block)`  
+Evaluates the *region* in the current buffer, inserts the result at
+*point* and returns it. If *mark* in the current buffer is before
+*point* `eval-block` evaluates this *region* and inserts the result at
+*point*. If *point* is before *mark* `eval-block` does nothing but
+returning `t`.
+
+`(system «string»)`  
+Executes the
+[system(1)](https://man7.org/linux/man-pages/man3/system.3.html)
+function with *string* as parameter.
+
+`(os.getenv «string») `  
+Returns the value of the environment variable named *string*.
+
+`(log-message «string»)`  
+Logs *string* to the `*messages*` buffer.
+
+`(log-debug «string»)`  
+Logs string to the file `debug.out`.
+
+`(get-version-string)`  
+Returns the complete version string of Femto, including the copyright.
+
+### Implementation Details
+
+<span class="mark">Tbd.: Memory consumption, limits, hacking, ...</span>

--- a/femto.rc
+++ b/femto.rc
@@ -9,6 +9,8 @@
 ;; For example: (set-key "c-k" "(kill-to-eol)")
 ;;
 
+;; Core fLisp extensions - this is a copy of the core.lsp library
+
 (setq list (lambda args args))
 
 (setq defmacro
@@ -67,6 +69,8 @@
 	 (cond ((memq feature features)	feature)))))
 
 (provide 'core)
+
+;; Batch mode processing and Femto editor startup
 
 (setq
  ~ (os.getenv "HOME")

--- a/file.c
+++ b/file.c
@@ -1,0 +1,18 @@
+#ifndef FILE_C
+#define FILE_C
+
+Object *primitiveFgetc(Object** args, GC_PARAM)
+{
+    Object *first = (*args)->car;
+    char s[] = "\0\0";
+
+    if (first->type != TYPE_STREAM)
+	exceptionWithObject(first, "not a stream");
+
+    int c = getc(first->fd);
+    if (c == EOF)
+	return nil;
+    s[0] = (char)c;
+    return newString(s, GC_ROOTS);
+}
+#endif

--- a/file.c
+++ b/file.c
@@ -21,6 +21,18 @@ Object *primitiveFflush(Object** args, GC_PARAM)
     return newNumber(file_fflush(&flisp, fd), GC_ROOTS);
 }
 
+off_t file_ftell(Interpreter *interp, Object *stream)
+{
+    return ftello(stream->fd);
+}
+Object *primitiveFtell(Object** args, GC_PARAM)
+{
+    ONE_STREAM_ARG(ftell);
+    if (fd->fd == NULL)
+        exception(&flisp, FLISP_INVALID_VALUE, "(ftell fd) - stream fd already closed");
+    return newNumber(file_ftell(&flisp, fd), GC_ROOTS);
+}
+
 Object *primitiveFgetc(Object** args, GC_PARAM)
 {
     char s[] = "\0\0";

--- a/file.c
+++ b/file.c
@@ -1,18 +1,44 @@
 #ifndef FILE_C
 #define FILE_C
 
+Object *primitiveFopen(Object ** args, GC_PARAM)
+{
+    TWO_STRING_ARGS(fopen);
+    return file_fopen(&flisp, first->string, second->string);
+}
+Object *primitiveFclose(Object** args, GC_PARAM)
+{
+    ONE_STREAM_ARG(fclose);
+    if (fd->fd == NULL)
+        exception(&flisp, FLISP_INVALID_VALUE, "(fflush fd) - stream fd already closed");
+    return newNumber(file_fclose(&flisp, fd), GC_ROOTS);
+}
+Object *primitiveFflush(Object** args, GC_PARAM)
+{
+    ONE_STREAM_ARG(fflush);
+    if (fd->fd == NULL)
+        exception(&flisp, FLISP_INVALID_VALUE, "(fflush fd) - stream fd already closed");
+    return newNumber(file_fflush(&flisp, fd), GC_ROOTS);
+}
+
 Object *primitiveFgetc(Object** args, GC_PARAM)
 {
-    Object *first = (*args)->car;
     char s[] = "\0\0";
-
-    if (first->type != TYPE_STREAM)
-	exceptionWithObject(first, "not a stream");
-
-    int c = getc(first->fd);
+    ONE_STREAM_ARG(getc);
+    
+    int c = getc(fd->fd);
     if (c == EOF)
 	return nil;
     s[0] = (char)c;
     return newString(s, GC_ROOTS);
 }
 #endif
+
+
+/*
+ * Local Variables:
+ * c-file-style: "k&r"
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/flisp.c
+++ b/flisp.c
@@ -1,0 +1,70 @@
+/*
+ * flisp.c, Georg Lehner, Public Domain, 2024
+ */
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include "lisp.h"
+
+#define CPP_XSTR(s) CPP_STR(s)
+#define CPP_STR(s) #s
+
+Interpreter *flisp_interp;
+
+void fatal(char *msg)
+{
+    fprintf(stderr, "\n%s %s:\n%s\n", FL_NAME, FL_VERSION, msg);
+    exit(1);
+}
+
+int main(int argc, char **argv)
+{
+    char *library_path, *init_file;
+    Interpreter *interp;
+    char input[INPUT_FMT_BUFSIZ];
+    ResultCode result = RESULT_OK;
+
+    if ((init_file = getenv("FLISPRC")) == NULL)
+        init_file = CPP_XSTR(E_INITFILE);
+    
+    if ((library_path=getenv("FLISPLIB")) == NULL)
+        library_path = CPP_XSTR(E_SCRIPTDIR);
+
+    interp = lisp_init(argc, argv, library_path);
+    if (interp == NULL)
+        fatal("fLisp initialization failed");
+
+    interp->output = file_fopen(interp, ">1", "");
+    interp->message = file_fopen(interp, ">2", "");
+    interp->debug = file_fopen(interp, ">2", "");
+
+    if (strlen(init_file)) {
+        // Note: we do not have input streams yet
+        result = lisp_eval(interp, "(load \"%s\"", init_file);
+        if (result)
+            return result;
+    }
+    
+    while(1) {
+        if (isatty(0))
+            write(0, "\n> ", 3);
+        fflush(stdout);
+        // Note: we do not have input streams yet
+        if (fgets(input, INPUT_FMT_BUFSIZ, stdin) == NULL) break;
+        
+        result = lisp_eval(interp, input);
+    }
+    puts("");
+    return result;
+}
+
+/*
+ * Local Variables:
+ * c-file-style: "k&r"
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/flisp.c
+++ b/flisp.c
@@ -12,7 +12,21 @@
 #define CPP_XSTR(s) CPP_STR(s)
 #define CPP_STR(s) #s
 
-Interpreter *flisp_interp;
+Interpreter *interp;
+Object *stderrStream;
+ResultCode result;
+
+// Note: wouldn't need, if we could implement the repl in fLisp
+#define INPUT_BUFSIZE 4095
+char input[INPUT_BUFSIZE+1]; // Note: termios paste limit or so
+
+#define FLUSH_STDOUT \
+    if (file_fflush(interp, interp->output)) \
+        fatal("failed to flush output stream")
+#define FLUSH_STDERR \
+    if (file_fflush(interp, stderrStream)) \
+        fatal("failed to flush error stream")
+
 
 void fatal(char *msg)
 {
@@ -20,12 +34,55 @@ void fatal(char *msg)
     exit(1);
 }
 
+// Note: we'd like to implement the repl() in fLisp itself, for this we'd need:
+// - isatty()
+// - exception handling in fLisp
+// - file output for error messages
+int repl(Interpreter *interp)
+{
+    ResultCode result;
+    size_t i;
+
+    writeString(interp->output, FL_NAME " " FL_VERSION "\n");
+    while (true) {
+        writeString(interp->output, "> ");
+        FLUSH_STDOUT;
+        FLUSH_STDERR;
+
+        if (!fgets(input, sizeof(input), stdin)) break;
+        i=strlen(input);
+        if (input[i-1] == '\n')
+            input[i-1] = '\0';
+        else {
+            writeString(stderrStream, "error: more then " CPP_STR(INPUT_BUFSIZ) "read, skipping...\n");
+            continue;
+        }
+        result = lisp_eval_string(interp, input);
+        if (result) {
+            writeString(stderrStream, "error: ");
+            if (interp->object != nil) {
+                writeString(stderrStream, "object '");
+                writeObject(stderrStream, interp->object, true);
+                writeString(stderrStream, "', ");
+            }
+
+            writeString(stderrStream, interp->message);
+            writeChar(stderrStream, '\n');
+        }
+    }
+    if (ferror(interp->input->fd))
+        fatal("failed to read input stream");
+
+    FLUSH_STDOUT;
+    FLUSH_STDERR;
+
+    return interp->result;
+}
+
 int main(int argc, char **argv)
 {
     char *library_path, *init_file, *debug_file;
-    Interpreter *interp;
-    char input[INPUT_FMT_BUFSIZ];
-    ResultCode result = FLISP_OK;
+    jmp_buf exceptionEnv;
 
     if ((init_file = getenv("FLISPRC")) == NULL)
         init_file = FL_LIBDIR "/" FL_INITFILE;
@@ -35,52 +92,53 @@ int main(int argc, char **argv)
 
     interp = lisp_init(argc, argv, library_path);
     if (interp == NULL)
-        fatal("fLisp initialization failed");
+        fatal("fLisp interpreter initialization failed");
 
     debug_file=getenv("FLISP_DEBUG");
 
-    interp->output = file_fopen(interp, ">1", "");
-    Object *stderrStream = file_fopen(interp, ">2", "");
+    if (nil == (interp->output = file_fopen(interp, ">1", "a")))
+        fatal("could not open output stream");
+    if (nil == (stderrStream = file_fopen(interp, ">2", "a")))
+        fatal("could not open error stream");
+    if (debug_file != NULL)
+        if (nil == (interp->debug = file_fopen(interp, debug_file, "w")))
+            fprintf(stderr, "failed to open debug file %s:%d: %s\n", debug_file, interp->result, interp->message);
 
-    if (debug_file != NULL) {
-        interp->debug = file_fopen(interp, debug_file, "w");
-    }
-
-    if (isatty(0)) {
-        printf(FL_NAME " " FL_VERSION "\n");
-        fflush(stdout);
-    }
     if (strlen(init_file)) {
-        // Note: we do not have input streams yet
-        snprintf(input, sizeof(input), "(load \"%s\"", init_file);
-        result = lisp_eval(interp, input);
+        if (nil == (interp->input = file_fopen(interp, init_file, "r")))
+            fprintf(stderr, "failed to open inifile %s:%d: %s\n", init_file, interp->result, interp->message);
+
+        interp->stackframe = &exceptionEnv;
+        result = lisp_eval(interp);
+        // Note: if we could implement the repl in fLisp itself we'd bail out here.
         if (result)
-            fprintf(stderr, "failed to load inifile %s: %s", init_file, interp->message);
+            fprintf(stderr, "failed to load inifile %s:%d: %s\n", init_file, interp->result, interp->message);
+        else
+            if (file_fclose(interp, interp->input))
+                fprintf(stderr, "failed to close inifile %s:%d %s\n", init_file, interp->result, interp->message);
+        interp->stackframe = NULL;
     }
+    if (nil == (interp->input = file_fopen(interp, "<0", "r")))
+        fatal("failed to open input stream");
 
-    while(true) {
-        if (isatty(0))
-            printf("\n> ");
-        fflush(stdout);
-        // Note: we do not have input streams yet
-        if (fgets(input, INPUT_FMT_BUFSIZ, stdin) == NULL) break;
+    //Note: could be omitted if we could implement the repl in fLisp itself.
+    if (isatty(fileno(interp->input->fd)))
+        return repl(interp);
 
-        if (input[strlen(input)-1] == '\n')
-            input[strlen(input)-1] = '\0';
-
-        result = lisp_eval(interp, input);
-        if (result) {
-            writeString(stderrStream, "error: ");
-            if (interp->object != nil) {
-                writeString(stderrStream, "object '");
-                writeObject(stderrStream, interp->object, true);
-                writeString(stderrStream, "', ");
-            }
-            writeString(stderrStream, interp->message);
-            fflush(stderrStream->fd);
+    interp->stackframe = &exceptionEnv;
+    result = lisp_eval(interp);
+    FLUSH_STDOUT;
+    if (result) {
+        writeString(stderrStream, "error: ");
+        if (interp->object != nil) {
+            writeString(stderrStream, "object '");
+            writeObject(stderrStream, interp->object, true);
+            writeString(stderrStream, "', ");
         }
+        writeString(stderrStream, interp->message);
+        FLUSH_STDERR;
+        return result;
     }
-    puts("");
     return 0;
 }
 

--- a/flisp.c
+++ b/flisp.c
@@ -52,7 +52,8 @@ int main(int argc, char **argv)
     }
     if (strlen(init_file)) {
         // Note: we do not have input streams yet
-        result = lisp_eval(interp, "(load \"%s\"", init_file);
+        snprintf(input, sizeof(input), "(load \"%s\"", init_file);
+        result = lisp_eval(interp, input);
         if (result)
             fprintf(stderr, "failed to load inifile %s: %s", init_file, interp->message);
     }

--- a/flisp.c
+++ b/flisp.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
 
     if ((init_file = getenv("FLISPRC")) == NULL)
         init_file = FL_LIBDIR "/" FL_INITFILE;
-    
+
     if ((library_path=getenv("FLISPLIB")) == NULL)
         library_path = CPP_XSTR(FL_LIBDIR);
 
@@ -38,14 +38,14 @@ int main(int argc, char **argv)
         fatal("fLisp initialization failed");
 
     debug_file=getenv("FLISP_DEBUG");
-    
+
     interp->output = file_fopen(interp, ">1", "");
     Object *stderrStream = file_fopen(interp, ">2", "");
 
-    if (debug_file != NULL) { 
+    if (debug_file != NULL) {
         interp->debug = file_fopen(interp, debug_file, "w");
     }
-    
+
     if (isatty(0)) {
         printf(FL_NAME " " FL_VERSION "\n");
         fflush(stdout);
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
 
         if (input[strlen(input)-1] == '\n')
             input[strlen(input)-1] = '\0';
-            
+
         result = lisp_eval(interp, input);
         if (result) {
             writeString(stderrStream, "error: ");

--- a/flisp.rc
+++ b/flisp.rc
@@ -1,0 +1,78 @@
+;; -*-Lisp-*-
+;;
+(setq list (lambda args args))
+
+(setq defmacro
+      (macro (name params . body)
+	     (list (quote setq) name (list (quote macro) params . body))))
+
+(defmacro defun (name params . body)
+  (list (quote setq) name (list (quote lambda) params . body)))
+
+(defun string (s)
+  ;; Convert argument to string.
+  ;; Common Lisp
+  (cond
+    ((eq nil s) "")
+    ((numberp s) (number-to-string s))
+    ((stringp s) s)
+    ((symbolp s) (symbol-name s))
+    ((consp s) (string.append (string (car s)) (string (cdr s))))
+    (t (signal 'wrong-type-argument (list "cannot convert to string" s)))))
+
+(defun concat args
+  ;; Concatenate all arguments to a string.
+  ;; Elisp
+  (cond
+    ((eq nil args) "")
+    ((eq nil (cdr args)) (string (car args)))
+    (t (string.append (string (car args)) (concat (cdr args)))) ))
+
+(defun memq (o l)
+  ;; If object o in list l return sublist of l starting with o, else nil.
+  ;; Elisp
+  (cond
+    ((eq nil o) nil)
+    ((eq nil l) nil)
+    ((eq o (car l)) l)
+    (t (memq o (cdr l)))))
+
+;; Features
+(setq features nil)
+
+(defun provide args
+  ;; args: (feature [subfeature ..])
+  ;; Elisp, subfeatures not implemented
+  (setq features (cons (car args) features)))
+
+(defun require args
+  ;; args: (feature [filename [noerror]])
+  ;; Elisp, optional parameters not implemented
+  (setq feature (car args))
+  (cond ((memq feature features) feature)
+	(t
+	 ;; Emacs optionally uses provided filename here
+	 (setq path (concat script_dir "/" (symbol-name feature) ".lsp"))
+	 (load path)
+	 ;; Emacs checks if load fails and returns nil instead of feature.
+	 (cond ((memq feature features)	feature)))))
+
+(provide 'core)
+
+(setq
+ ~ (os.getenv "HOME")
+ config_file (concat ~ "/" ".config/flisp/flisp.rc"))
+
+(defun getopts (opts pos)
+  (setq o (car opts))
+  (cond
+    ((null o))
+    (t
+     (load o)
+     (getopts (cdr opts) 0))))
+
+(require 'flisp)
+(require 'stdlib)
+
+;; if not found we get not past this but rather err out: (load config_file)
+(getopts argv 0)

--- a/funcmap.c
+++ b/funcmap.c
@@ -366,18 +366,8 @@ void execute_command()
         funct = name_to_function(command_name);
 
         if (funct == NULL || funct == user_func) {
-            char funcname[80];
-            sprintf(funcname, "(%s)", command_name);
-            char *output = call_lisp(funcname);
-
-            /* show errors on message line */
-            /* can probably make this a common function */                
-            if (NULL != strstr(output, "error:")) {
-                char buf[81];
-                strncpy(buf, output, 80);
-                buf[80] ='\0';
-                msg(buf);
-            }    
+            if (lisp_eval(flisp_interp, "(%s)", command_name) != RESULT_OK)
+                msg("error: %s", flisp_interp->message);
         } else {
             (funct)();
         }

--- a/funcmap.c
+++ b/funcmap.c
@@ -366,8 +366,9 @@ void execute_command()
         funct = name_to_function(command_name);
 
         if (funct == NULL || funct == user_func) {
-            if (lisp_eval(flisp_interp, "(%s)", command_name) != RESULT_OK)
-                msg("error: %s", flisp_interp->message);
+            
+            if (eval_string(true, "(%s)", command_name) != NULL)
+                close_eval();
         } else {
             (funct)();
         }

--- a/gap.c
+++ b/gap.c
@@ -100,7 +100,7 @@ point_t pos(buffer_t *bp, register char_t *cp)
 
 int posix_file(char *fn)
 {
-    if (fn[0] == '_')
+    if (fn[0] == '-')
         return (FALSE);
 
     for (; *fn != '\0'; ++fn) {

--- a/header.h
+++ b/header.h
@@ -1,5 +1,4 @@
 #define VALGRIND 0
-
 /*
  * header.h, femto, Hugh Barney, 2023
  * Derived from: Anthony's Editor January 93, (Public Domain 1991, 1993 by Anthony Howe)
@@ -19,10 +18,11 @@
 #include <string.h>
 #include <unistd.h>
 #include <wchar.h>
+#include "lisp.h"
 int mkstemp(char *);
 
 #define E_NAME          "femto"
-#define E_VERSION       "2.18"
+#define E_VERSION       "2.19"
 #define E_LABEL         "Femto:"
 #define E_NOT_BOUND     "<not bound>"
 #ifndef E_SCRIPTDIR
@@ -31,7 +31,7 @@ int mkstemp(char *);
 #ifndef E_INITFILE
 #define E_INITFILE      "/usr/local/share/femto/femto.rc"
 #endif
-#define E_VERSION_STR    E_NAME " " E_VERSION ", Public Domain, March 2024, by Hugh Barney,  No warranty."
+#define E_VERSION_STR    E_NAME " " E_VERSION ", Public Domain, October 2024, by Hugh Barney,  No warranty."
 
 #define MSGLINE         (LINES-1)
 #define NOMARK          -1

--- a/header.h
+++ b/header.h
@@ -333,6 +333,7 @@ extern void log_message(char *);
 extern void match_paren_backwards(buffer_t *, char, char);
 extern void match_paren_forwards(buffer_t *, char, char);
 extern void match_parens();
+extern void suspend();
 extern void quit();
 extern void quit_ask();
 extern void readfile(char *);

--- a/header.h
+++ b/header.h
@@ -488,7 +488,8 @@ extern window_t *popup_window(char *);
 extern window_t *split_current_window();
 
 /* fLisp interpreter used for femto */
-extern Interpreter *flisp_interp;
+extern char *eval_string(int, char *, ...);
+extern void close_eval();
 
 
 /*

--- a/header.h
+++ b/header.h
@@ -423,10 +423,6 @@ extern void execute_key();
 extern void make_key(char *, char *);
 extern void setup_keys();
 
-/* functions in lisp.c */
-extern char *call_lisp(char *);
-extern int init_lisp(int, char**, char*);
-
 /* functions in main.c */
 extern int main(int argc, char **);
 extern void debug(char *format, ...);
@@ -489,6 +485,10 @@ extern window_t *find_window(char *);
 extern window_t* new_window();
 extern window_t *popup_window(char *);
 extern window_t *split_current_window();
+
+/* fLisp interpreter used for femto */
+extern Interpreter *flisp_interp;
+
 
 /*
  * Local Variables:

--- a/header.h
+++ b/header.h
@@ -22,7 +22,7 @@
 int mkstemp(char *);
 
 #define E_NAME          "femto"
-#define E_VERSION       "2.19"
+#define E_VERSION       "2.20"
 #define E_LABEL         "Femto:"
 #define E_NOT_BOUND     "<not bound>"
 #ifndef E_SCRIPTDIR

--- a/hilite.c
+++ b/hilite.c
@@ -8,7 +8,7 @@ int skip_count = 0;
 
 char_t get_at(buffer_t *bp, point_t pt)
 {
-    // Note: ptr get's it wrong here when at the end
+    // Note: ptr get's it wrong here: when at the end
     //   Valgrind complains, the pointer is behind 0 bytes
     //   However somewhere else it is needed exactly this way
     //   otherwise we get an extra zero byte at the end of the buffer.

--- a/key.c
+++ b/key.c
@@ -146,6 +146,7 @@ void setup_keys()
     set_key_internal("c-v",     "forward-page"          , "\x16", forward_page);
     set_key_internal("c-w",     "kill-region"           , "\x17", kill_region);
     set_key_internal("c-y",     "yank"                  , "\x19", yank);
+    set_key_internal("c-z",     "suspend"               , "\x1A", suspend);
 
     set_key_internal("esc-!",   "shell-command"         , "\x1B\x21", user_func);
     set_key_internal("esc-a",   "apropos"               , "\x1B\x61", apropos);

--- a/key.c
+++ b/key.c
@@ -72,7 +72,7 @@ void create_keys()
         ctrx_map2[4] = ch + 96;
         ctrx_bytes[1] = ch + 96;
         make_key(ctrx_map2, ctrx_bytes);
-    }    
+    }
 
     /* control-c control-a to z */
     for (ch = 1; ch <= 26; ch++) {
@@ -92,7 +92,7 @@ void create_keys()
 int set_key_internal(char *name, char *funcname, char *bytes, void (*func)(void))
 {
     keymap_t *kp;
-    
+
     /* check if we have an existing key, if so update it */
     for (kp = khead; kp->k_next != NULL; kp = kp->k_next) {
         if (0 == strcmp(kp->k_name, name)) {
@@ -166,7 +166,7 @@ void setup_keys()
     set_key_internal("esc-w",   "copy-region"           , "\x1B\x77", copy_region);
     set_key_internal("esc-x",   "execute-command"       , "\x1B\x78", execute_command);
 
-    set_key_internal("esc-up",    "beginning-of-buffer" , "\x1B\x1B\x5B\x41", beginning_of_buffer);    
+    set_key_internal("esc-up",    "beginning-of-buffer" , "\x1B\x1B\x5B\x41", beginning_of_buffer);
     set_key_internal("esc-down",  "end-of-buffer"       , "\x1B\x1B\x5B\x42", end_of_buffer);
     set_key_internal("esc-right", "user-func"           , "\x1B\x1B\x5B\x43", user_func);
     set_key_internal("esc-left",  "user-func"           , "\x1B\x1B\x5B\x44", user_func);
@@ -184,8 +184,13 @@ void setup_keys()
     set_key_internal("down",      "next-line",            "\x1B\x5B\x42", down);
     set_key_internal("left",      "backward-char",        "\x1B\x5B\x44", left);
     set_key_internal("right",     "forward-char",         "\x1B\x5B\x43", right);
+    // rmkx mode
+    set_key_internal("home",      "beginning-of-line",    "\x1B\x5B\x48", lnbegin);
+    set_key_internal("end",       "end-of-line",          "\x1B\x5B\x46", lnend);
+    // smkx mode
     set_key_internal("home",      "beginning-of-line",    "\x1B\x4F\x48", lnbegin);
     set_key_internal("end",       "end-of-line",          "\x1B\x4F\x46", lnend);
+
     set_key_internal("del",       "delete",               "\x1B\x5B\x33\x7E", delete);
     set_key_internal("ins",       "toggle-overwrite-mode" , "\x1B\x5B\x32\x7E", toggle_overwrite_mode);
     set_key_internal("pgup",      "page-up",              "\x1B\x5B\x35\x7E", backward_page);
@@ -193,9 +198,9 @@ void setup_keys()
     set_key_internal("backspace", "backspace",            "\x7f", backspace);
 
     set_key_internal("c-x c-c",   "exit"                  , "\x18\x03", quit_ask);
-    set_key_internal("c-x c-f",   "find-file"             , "\x18\x06", i_readfile);  
+    set_key_internal("c-x c-f",   "find-file"             , "\x18\x06", i_readfile);
     set_key_internal("c-x c-n",   "next-buffer"           , "\x18\x0E", next_buffer);
-    set_key_internal("c-x c-s",   "save-buffer"           , "\x18\x13", savebuffer);  
+    set_key_internal("c-x c-s",   "save-buffer"           , "\x18\x13", savebuffer);
     set_key_internal("c-x c-w",   "write-file"            , "\x18\x17", writefile);
     set_key_internal("c-x 1",     "delete-other-windows"  , "\x18\x31", delete_other_windows);
     set_key_internal("c-x 2",     "split-window"          , "\x18\x32", split_window);

--- a/lisp.c
+++ b/lisp.c
@@ -1389,6 +1389,10 @@ Object *primitiveFclose(Object** args, GC_PARAM)
     first->fd = NULL;
     return newNumber(0, GC_ROOTS);
 }
+#ifdef FLISP_FILE_EXTENSION
+#include "file.c"
+#endif
+
 Object *e_get_version_string(Object ** args, GC_PARAM)
 {
     char *ver = get_version_string();
@@ -1734,7 +1738,7 @@ Primitive primitives[] = {
     {"load", 1, 1, e_load},
     {"os.getenv", 1, 1, os_getenv},
     {"get-temp-file", 0, 0, e_get_temp_file},
-
+    FLISP_REGISTER_FILE_EXTENSION
     {"add-mode-global", 1, 1, e_add_mode_global},
     {"message", 1, 1, e_message},
     {"log-message", 1, 1, e_log_message},

--- a/lisp.c
+++ b/lisp.c
@@ -273,6 +273,9 @@ void gc(GC_PARAM)
             object->vars = gcMoveObject(object->vars);
             object->vals = gcMoveObject(object->vals);
             break;
+        case TYPE_MOVED:
+            exceptionWithObject(object, "object already moved");
+            break;
         }
     }
 
@@ -819,6 +822,9 @@ void writeObject(Object * object, bool readably, Stream *stream)
         CASE(TYPE_MACRO, "Macro", object->params);
         CASE(TYPE_ENV, "Env", object->vars);
 #undef CASE
+    case TYPE_MOVED:
+        writeString("#<Error: gc moved object>", stream);
+        break;
     }
 }
 

--- a/lisp.c
+++ b/lisp.c
@@ -2293,26 +2293,12 @@ Interpreter *lisp_init(int argc, char **argv, char *library_path)
  * error message.
  *
  */
-ResultCode lisp_eval(Interpreter *interp, char * format, ...)
+ResultCode lisp_eval(Interpreter *interp, char * input)
 {
-    char input[INPUT_FMT_BUFSIZ];
-    va_list args;
-    int size;
     jmp_buf exceptionEnv;
     ResultCode result;
 
-    va_start (args, format);
-
-    size = vsnprintf (input, sizeof(input), format, args);
-    va_end(args);
-
-    // Note: instead of mitigation allocate dynamically and error only on OOM
-    if (size > INPUT_FMT_BUFSIZ) {
-        interp->result = FLISP_IO_ERROR;
-        strncpy(interp->message, "input string larger then " "WRITE_FMT_BUFSIZ", sizeof(interp->message));
-        return interp->result;
-    }
-    debug(interp, "lisp_eval(\"%s\")", input);
+    fl_debug(interp, "lisp_eval(\"%s\")", input);
 
     interp->message[0] = '\0';
     interp->result = FLISP_OK;

--- a/lisp.c
+++ b/lisp.c
@@ -222,7 +222,7 @@ Object *gcMoveObject(Object * object)
         return object;
 
     // if the object has already been moved, return its new location
-    if (object->type == (Type) - 1)
+    if (object->type == TYPE_MOVED)
         return object->forward;
 
     // copy object to to-space
@@ -231,7 +231,7 @@ Object *gcMoveObject(Object * object)
     flisp.memory->toOffset += object->size;
 
     // mark object as moved and set forwarding pointer
-    object->type = (Type) - 1;
+    object->type = TYPE_MOVED;
     object->forward = forward;
 
     return object->forward;
@@ -239,6 +239,8 @@ Object *gcMoveObject(Object * object)
 
 void gc(GC_PARAM)
 {
+    debug("collecting garbage\n");
+
     flisp.memory->toOffset = 0;
 
     // move symbols and root objects
@@ -288,7 +290,7 @@ size_t memoryAlign(size_t size, size_t alignment)
     return (size + alignment - 1) & ~(alignment - 1);
 }
 
-Object *memoryAllocObject(Type type, size_t size, GC_PARAM)
+Object *memoryAllocObject(ObjectType type, size_t size, GC_PARAM)
 {
     size = memoryAlign(size, sizeof(void *));
 
@@ -316,7 +318,7 @@ Object *memoryAllocObject(Type type, size_t size, GC_PARAM)
 
 // CONSTRUCTING OBJECTS ///////////////////////////////////////////////////////
 
-Object *newObject(Type type, GC_PARAM)
+Object *newObject(ObjectType type, GC_PARAM)
 {
     return memoryAllocObject(type, sizeof(Object), GC_ROOTS);
 }
@@ -335,7 +337,7 @@ Object *newNumber(double number, GC_PARAM)
     return object;
 }
 
-Object *newObjectWithString(Type type, size_t size, GC_PARAM)
+Object *newObjectWithString(ObjectType type, size_t size, GC_PARAM)
 {
     size = (size > sizeof(((Object *) NULL)->string))
         ? size - sizeof(((Object *) NULL)->string)
@@ -422,7 +424,7 @@ Object *newSymbol(char *string, GC_PARAM)
     return newSymbolWithLength(string, strlen(string), GC_ROOTS);
 }
 
-Object *newObjectWithClosure(Type type, Object ** params, Object ** body, Object ** env, GC_PARAM)
+Object *newObjectWithClosure(ObjectType type, Object ** params, Object ** body, Object ** env, GC_PARAM)
 {
     Object *list;
 

--- a/lisp.c
+++ b/lisp.c
@@ -71,7 +71,6 @@ void writeFmt(Stream *, char *format, ...)
 #endif
 
 void writeObject(Object * object, bool readably, Stream *);
-#define WRITE_FMT_BUFSIZ 2048
 
 void writeString(char *str, Stream *stream)
 {
@@ -104,6 +103,7 @@ void writeFmt(Stream *stream, char *format, ...)
 
     va_list args;
     va_start(args, format);
+    // Note: potentially truncates output to WRITE_FMT_BUFSIZ
     nbytes = vsnprintf(buf, WRITE_FMT_BUFSIZ, format, args);
     va_end(args);
 
@@ -995,7 +995,7 @@ Object *primitiveSignal(Object ** args, GC_PARAM)
     exceptionWithObject(*e, first->string);
     return *e;
 }
-    
+
 /************************* Editor Extensions **************************************/
 
 #define DEFINE_EDITOR_FUNC(name)                \

--- a/lisp.c
+++ b/lisp.c
@@ -1136,7 +1136,7 @@ DEFINE_PRIMITIVE_RELATIONAL(primitiveGreaterEqual, >=)
 
 #define ONE_STREAM_ARG(func)                                  \
     Object *fd = (*args)->car;                            \
-    if (stream->type != TYPE_STREAM)                          \
+    if (fd->type != TYPE_STREAM)                          \
         exceptionWithObject(&flisp, fd, FLISP_WRONG_TYPE, "(" CPP_XSTR(func) " fd) - fd is not a stream");
 
 Object *fl_system(Object ** args, GC_PARAM) {

--- a/lisp.c
+++ b/lisp.c
@@ -1026,6 +1026,7 @@ DEFINE_EDITOR_FUNC(delete)
 DEFINE_EDITOR_FUNC(backspace)
 DEFINE_EDITOR_FUNC(forward_page)
 DEFINE_EDITOR_FUNC(backward_page)
+DEFINE_EDITOR_FUNC(suspend)
 DEFINE_EDITOR_FUNC(quit)
 DEFINE_EDITOR_FUNC(eval_block)
 DEFINE_EDITOR_FUNC(delete_other_windows)
@@ -1697,6 +1698,7 @@ Primitive primitives[] = {
     {"other-window", 0, 0, e_other_window},
     {"get-clipboard", 0, 0, e_get_clipboard},
     {"get-buffer-count", 0, 0, e_get_buffer_count},
+    {"suspend", 0, 0, e_suspend},
     {"exit", 0, 0, e_quit}
 };
 

--- a/lisp.c
+++ b/lisp.c
@@ -823,7 +823,7 @@ void writeObject(Object * object, bool readably, Stream *stream)
         CASE(TYPE_ENV, "Env", object->vars);
 #undef CASE
     case TYPE_MOVED:
-        writeString("#<Error: gc moved object>", stream);
+        exception("won't write a garbage collected item");
         break;
     }
 }

--- a/lisp.h
+++ b/lisp.h
@@ -10,7 +10,7 @@
 #include <stdbool.h>
 
 #define FL_NAME     "fLisp"
-#define FL_VERSION  "0.1"
+#define FL_VERSION  "0.2"
 
 #define FL_INITFILE "flisp.rc"
 #define FL_LIBDIR "/usr/local/share/flisp"

--- a/lisp.h
+++ b/lisp.h
@@ -113,7 +113,8 @@ typedef struct Interpreter {
 extern Interpreter *lisp_interpreters;
 
 extern Interpreter *lisp_init(int, char**, char*);
-extern ResultCode lisp_eval(Interpreter *, char *);
+extern ResultCode lisp_eval(Interpreter *);
+extern ResultCode lisp_eval_string(Interpreter *, char *);
 
 Object *file_fopen(Interpreter *, char *, char*);
 int file_fclose(Interpreter *, Object *);

--- a/lisp.h
+++ b/lisp.h
@@ -8,6 +8,10 @@
 #include <setjmp.h>
 #include <stdio.h>
 
+#define FL_NAME     "fLisp"
+#define FL_VERSION  "0.1"
+
+
 //#define FLISP_MEMORY_SIZE          131072UL
 //#define FLISP_MEMORY_SIZE          262144UL  /* 256k */
 //#define FLISP_MEMORY_SIZE          524288UL
@@ -84,16 +88,16 @@ typedef struct Memory {
 
 typedef struct Interpreter Interpreter;
 typedef struct Interpreter {
-    char * output;                   /* output of last evaluation, NULL if writing to STDOUT */
+    Object *output;                  /* output stream */
+    Object *message;                 /* error stream */
+    Object *debug;                   /* debug stream */
     ResultCode result;               /* result of last evaluation */
-    char message[WRITE_FMT_BUFSIZ];  /* last error message */
     /* private */
     Object *theRoot;      /* root object */
     Object **theEnv;      /* environment object */
     Object *symbols;      /* symbols list */
     Object root;          /* reified root node */
     Stream *istream;      /* Lisp input stream */
-    Stream ostream;       /* Lisp output stream */
     Memory *memory;       /* memory available for object allocation,
                              cleaned up by garbage collector */
     jmp_buf *stackframe;  /* exception handling */
@@ -103,8 +107,10 @@ typedef struct Interpreter {
 extern Interpreter *lisp_interpreters;
 
 extern Interpreter *lisp_init(int, char**, char*);
-extern ResultCode lisp_eval(Interpreter*, char *, ...);
+extern ResultCode lisp_eval(Interpreter *, char *, ...);
 
+Object *file_fopen(Interpreter *, char *, char*);
+Object *file_fclose(Interpreter *, Object *);
 
 #ifdef FLISP_FILE_EXTENSION
 

--- a/lisp.h
+++ b/lisp.h
@@ -1,0 +1,112 @@
+#ifndef LISP_H
+#define LISP_H
+/*
+ * lisp.h, femto, Georg Lehner, 2024
+ * fLisp header file
+ *
+ */
+#include <setjmp.h>
+
+//#define FLISP_MEMORY_SIZE          131072UL
+//#define FLISP_MEMORY_SIZE          262144UL  /* 256k */
+//#define FLISP_MEMORY_SIZE          524288UL
+#define FLISP_MEMORY_SIZE         4194304UL  /* 4M */
+
+/* buffersize for Lisp eval input */
+#define INPUT_FMT_BUFSIZ 2048
+/* buffersize for Lisp result output */
+#define WRITE_FMT_BUFSIZ 2048
+
+/* Lisp objects */
+
+typedef struct Object Object;
+
+typedef enum ObjectType {
+    TYPE_NUMBER,
+    TYPE_STRING,
+    TYPE_SYMBOL,
+    TYPE_CONS,
+    TYPE_LAMBDA,
+    TYPE_MACRO,
+    TYPE_PRIMITIVE,
+    TYPE_ENV,
+    TYPE_MOVED = -1
+} ObjectType;
+
+struct Object {
+    ObjectType type;
+    size_t size;
+    union {
+        struct { double number; };                      // number
+        struct { char string[sizeof (Object *[3])]; };  // string, symbol
+        struct { Object *car, *cdr; };                  // cons
+        struct { Object *params, *body, *env; };        // lambda, macro
+        struct { int primitive; char *name; };          // primitive
+        struct { Object *parent, *vars, *vals; };       // env
+        struct { Object *forward; };                    // forwarding pointer
+    };
+};
+
+extern Object *nil;
+extern Object *t;
+
+
+typedef enum ResultCode {
+    RESULT_OK,
+    RESULT_ERROR
+} ResultCode; 
+
+// Note: WIP, relevant procedures must get a handle to the
+//   Interpreter, instead of accessing the static allocated flisp.
+//   init_lisp() must allocate the memory by itself and return an
+//   Interpreter to be used by call_lisp().
+
+typedef enum StreamType {
+    STREAM_TYPE_STRING,
+    STREAM_TYPE_FILE
+} StreamType;
+
+typedef struct Stream {
+    StreamType type;
+    char *buffer;
+    int fd;
+    size_t length, capacity;
+    off_t offset, size;
+} Stream;
+
+typedef struct Memory {
+    size_t capacity, fromOffset, toOffset;
+    void *fromSpace, *toSpace;
+} Memory;
+
+typedef struct Interpreter Interpreter;
+typedef struct Interpreter {
+    char * output;                   /* output of last evaluation, NULL if writing to STDOUT */
+    ResultCode result;               /* result of last evaluation */
+    char message[WRITE_FMT_BUFSIZ];  /* last error message */
+    /* private */
+    Object *theRoot;      /* root object */
+    Object **theEnv;      /* environment object */
+    Object *symbols;      /* symbols list */
+    Object root;          /* reified root node */
+    Stream *istream;      /* Lisp input stream */
+    Stream ostream;       /* Lisp output stream */
+    Memory *memory;       /* memory available for object allocation,
+                             cleaned up by garbage collector */
+    jmp_buf *stackframe;  /* exception handling */
+    Interpreter *next;    /* linked list of interpreters */
+} Interpreter;
+
+extern Interpreter *lisp_interpreters;
+
+extern Interpreter *lisp_init(int, char**, char*);
+extern ResultCode lisp_eval(Interpreter*, char *, ...);
+
+#endif
+/*
+ * Local Variables:
+ * c-file-style: "k&r"
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/lisp.h
+++ b/lisp.h
@@ -140,6 +140,7 @@ void writeObject(Object *, Object *, bool);
     {"fopen", 2, 2, primitiveFopen}, \
     {"fclose", 1, 1, primitiveFclose}, \
     {"fflush", 1, 1, primitiveFflush}, \
+    {"ftell", 1, 1, primitiveFtell}, \
     {"fgetc", 1, 1, primitiveFgetc},
 #else
 #define FLISP_REGISTER_FILE_EXTENSION

--- a/lisp.h
+++ b/lisp.h
@@ -139,7 +139,7 @@ void writeObject(Object *, Object *, bool);
 #define FLISP_REGISTER_FILE_EXTENSION \
     {"fopen", 2, 2, primitiveFopen}, \
     {"fclose", 1, 1, primitiveFclose}, \
-    {"fflush", 1, 1, primitiveFflush), \
+    {"fflush", 1, 1, primitiveFflush}, \
     {"fgetc", 1, 1, primitiveFgetc},
 #else
 #define FLISP_REGISTER_FILE_EXTENSION

--- a/lisp.h
+++ b/lisp.h
@@ -124,10 +124,11 @@ typedef struct Interpreter {
 extern Interpreter *lisp_interpreters;
 
 extern Interpreter *lisp_init(int, char**, char*);
-extern ResultCode lisp_eval(Interpreter *, char *, ...);
+extern ResultCode lisp_eval(Interpreter *, char *);
 
 Object *file_fopen(Interpreter *, char *, char*);
-Object *file_fclose(Interpreter *, Object *);
+int file_fclose(Interpreter *, Object *);
+int file_fflush(Interpreter *, Object *);
 
 void writeChar(Object *, char);
 void writeString(Object *, char *);
@@ -135,14 +136,13 @@ void writeObject(Object *, Object *, bool);
 
 
 #ifdef FLISP_FILE_EXTENSION
-
 #define FLISP_REGISTER_FILE_EXTENSION \
     {"fopen", 2, 2, primitiveFopen}, \
     {"fclose", 1, 1, primitiveFclose}, \
+    {"fflush", 1, 1, primitiveFflush), \
     {"fgetc", 1, 1, primitiveFgetc},
 #else
 #define FLISP_REGISTER_FILE_EXTENSION
-
 #endif
 
 

--- a/lisp.h
+++ b/lisp.h
@@ -68,6 +68,7 @@ typedef enum ResultCode {
     /* Parser/reader */
     FLISP_READ_INCOMPLETE,
     FLISP_READ_INVALID,
+    FLISP_READ_RANGE, /* number range over/underflow */
     /* Parameter */
     FLISP_WRONG_TYPE,
     FLISP_INVALID_VALUE,
@@ -84,19 +85,6 @@ typedef enum ResultCode {
 //   init_lisp() must allocate the memory by itself and return an
 //   Interpreter to be used by call_lisp().
 
-typedef enum StreamType {
-    STREAM_TYPE_STRING,
-    STREAM_TYPE_FILE
-} StreamType;
-
-typedef struct Stream {
-    StreamType type;
-    char *buffer;
-    int fd;
-    size_t length, capacity;
-    off_t offset, size;
-} Stream;
-
 typedef struct Memory {
     size_t capacity, fromOffset, toOffset;
     void *fromSpace, *toSpace;
@@ -104,6 +92,7 @@ typedef struct Memory {
 
 typedef struct Interpreter Interpreter;
 typedef struct Interpreter {
+    Object *input;                   /* input stream */
     Object *output;                  /* output stream */
     Object *object;                  /* result or error object */
     char message[WRITE_FMT_BUFSIZ];  /* error string */
@@ -114,10 +103,10 @@ typedef struct Interpreter {
     Object **theEnv;      /* environment object */
     Object *symbols;      /* symbols list */
     Object root;          /* reified root node */
-    Stream *istream;      /* Lisp input stream */
     Memory *memory;       /* memory available for object allocation,
                              cleaned up by garbage collector */
     jmp_buf *stackframe;  /* exception handling */
+    struct { char *buf; size_t len; size_t capacity; };  /* read buffer */
     Interpreter *next;    /* linked list of interpreters */
 } Interpreter;
 

--- a/lisp.h
+++ b/lisp.h
@@ -6,6 +6,7 @@
  *
  */
 #include <setjmp.h>
+#include <stdio.h>
 
 //#define FLISP_MEMORY_SIZE          131072UL
 //#define FLISP_MEMORY_SIZE          262144UL  /* 256k */
@@ -30,6 +31,7 @@ typedef enum ObjectType {
     TYPE_MACRO,
     TYPE_PRIMITIVE,
     TYPE_ENV,
+    TYPE_STREAM,
     TYPE_MOVED = -1
 } ObjectType;
 
@@ -43,6 +45,7 @@ struct Object {
         struct { Object *params, *body, *env; };        // lambda, macro
         struct { int primitive; char *name; };          // primitive
         struct { Object *parent, *vars, *vals; };       // env
+        struct { Object *path; FILE *fd; char *buf; size_t len; }; // file descriptor/stream
         struct { Object *forward; };                    // forwarding pointer
     };
 };
@@ -54,7 +57,7 @@ extern Object *t;
 typedef enum ResultCode {
     RESULT_OK,
     RESULT_ERROR
-} ResultCode; 
+} ResultCode;
 
 // Note: WIP, relevant procedures must get a handle to the
 //   Interpreter, instead of accessing the static allocated flisp.

--- a/lisp.h
+++ b/lisp.h
@@ -105,6 +105,19 @@ extern Interpreter *lisp_interpreters;
 extern Interpreter *lisp_init(int, char**, char*);
 extern ResultCode lisp_eval(Interpreter*, char *, ...);
 
+
+#ifdef FLISP_FILE_EXTENSION
+
+#define FLISP_REGISTER_FILE_EXTENSION \
+    {"fopen", 2, 2, primitiveFopen}, \
+    {"fclose", 1, 1, primitiveFclose}, \
+    {"fgetc", 1, 1, primitiveFgetc},
+#else
+#define FLISP_REGISTER_FILE_EXTENSION
+
+#endif
+
+
 #endif
 /*
  * Local Variables:

--- a/lisp/core.lsp
+++ b/lisp/core.lsp
@@ -1,0 +1,63 @@
+;; -*-Lisp-*-
+;;
+;; Core fLisp extensions
+;;
+
+(setq list (lambda args args))
+
+(setq defmacro
+      (macro (name params . body)
+	     (list (quote setq) name (list (quote macro) params . body))))
+
+(defmacro defun (name params . body)
+  (list (quote setq) name (list (quote lambda) params . body)))
+
+(defun string (s)
+  ;; Convert argument to string.
+  ;; Common Lisp
+  (cond
+    ((eq nil s) "")
+    ((numberp s) (number-to-string s))
+    ((stringp s) s)
+    ((symbolp s) (symbol-name s))
+    ((consp s) (string.append (string (car s)) (string (cdr s))))
+    (t (signal 'wrong-type-argument (list "cannot convert to string" s)))))
+
+(defun concat args
+  ;; Concatenate all arguments to a string.
+  ;; Elisp
+  (cond
+    ((eq nil args) "")
+    ((eq nil (cdr args)) (string (car args)))
+    (t (string.append (string (car args)) (concat (cdr args)))) ))
+
+(defun memq (o l)
+  ;; If object o in list l return sublist of l starting with o, else nil.
+  ;; Elisp
+  (cond
+    ((eq nil o) nil)
+    ((eq nil l) nil)
+    ((eq o (car l)) l)
+    (t (memq o (cdr l)))))
+
+;; Features
+(setq features nil)
+
+(defun provide args
+  ;; args: (feature [subfeature ..])
+  ;; Elisp, subfeatures not implemented
+  (setq features (cons (car args) features)))
+
+(defun require args
+  ;; args: (feature [filename [noerror]])
+  ;; Elisp, optional parameters not implemented
+  (setq feature (car args))
+  (cond ((memq feature features) feature)
+	(t
+	 ;; Emacs optionally uses provided filename here
+	 (setq path (concat script_dir "/" (symbol-name feature) ".lsp"))
+	 (load path)
+	 ;; Emacs checks if load fails and returns nil instead of feature.
+	 (cond ((memq feature features)	feature)))))
+
+(provide 'core)

--- a/lisp/femto.lsp
+++ b/lisp/femto.lsp
@@ -172,4 +172,21 @@
        ((eq -1 start_p) (message "could not find start of s-expression"))
        ((eq -1 end_p) (message "could not find end of s-expression"))) )))
 
+(defun transpose-chars ()
+  (cond 
+    ((= (get-point) 0) (message "Beginning of buffer"))
+    (t 
+      (cond
+        ((eq (get-char) "\n")
+	  (setq p (get-point))
+          (backward-char)
+          (transpose-chars)
+          (set-point p))
+        (t
+          (backward-char)
+          (setq c (get-char))
+          (delete)
+          (forward-char)
+          (insert-string c))))))
+
 (provide 'femto)

--- a/lisp/femto.lsp
+++ b/lisp/femto.lsp
@@ -1,8 +1,12 @@
+;; -*-Lisp-*-
 ;;
 ;; Basic Femto extensions
 ;;
 
 (require 'flisp)
+
+(defun load-script(fn)
+  (load (concat script_dir "/" fn)))
 
 (defun repeat (n func)  
   (cond ((> n 0) (func) (repeat (- n 1) func))))

--- a/lisp/flisp.lsp
+++ b/lisp/flisp.lsp
@@ -1,8 +1,5 @@
 ;; flisp Language
 
-(defun load-script(fn)
-  (load (concat script_dir "/" fn)))
-
 ;; Expected Lisp idioms
 
 (setq not null)
@@ -51,4 +48,5 @@
 (defun nth (n list)
   (car (nthcdr n list)))
 
+(require 'core)
 (provide 'flisp)

--- a/lisp/git.lsp
+++ b/lisp/git.lsp
@@ -4,7 +4,7 @@
 ;; (load_script "git.lsp")   ;; to load
 ;; (git-menu)                ;; to call
 ;;
-(require 'flisp)
+(require 'femto)
 
 (setq git-help-string
 "

--- a/lisp/startup.lsp
+++ b/lisp/startup.lsp
@@ -56,6 +56,7 @@
 ;;  Key Bindings, setkey is used to bind keys to user defined functions in lisp
 ;;
 
+(set-key "c-t" "transpose-chars")
 (set-key "c-x @" "shell-command") ;; femto
 (set-key "esc !" "shell-command")
 (set-key "c-x i" "insert-file")

--- a/lisp/startup.lsp
+++ b/lisp/startup.lsp
@@ -44,22 +44,13 @@
 (require 'bufmenu)
 (require 'dired)
 (require 'grep)
+(require 'git)
+(require 'oxo)
 
 (defun show-info ()
   ;; autoload info with c-x h
   (require 'info)
   (show-info))
-
-;; oxo and git fail when loaded on startup
-(defun oxo ()
-  ;; autoload oxo with c-x o
-  (require 'oxo)
-  (oxo))
-
-(defun git-menu ()
-  ;; autoload git with c-x g
-  (require 'git)
-  (git-menu))
 
 ;;
 ;;  Key Bindings, setkey is used to bind keys to user defined functions in lisp
@@ -89,5 +80,5 @@
  config_dir ".config/femto"
  config_file "femto.rc")
 
-(trap (load (confn config_file)))
+(load (confn config_file))
 (getopts argv 0)

--- a/main.c
+++ b/main.c
@@ -41,13 +41,14 @@ int main(int argc, char **argv)
         fatal("fLisp initialization failed");
 
     if (debug_mode)
-        // Note: file_fopen can raise IO exception, 
-        flisp_interp->debug = file_fopen(flisp_interp, "debug.out", "a");
+        if (nil == (flisp_interp->debug = file_fopen(flisp_interp, "debug.out", "a")))
+            fatal("could not open debug stream");
     
     if ((init_file = getenv("FEMTORC")) == NULL)
         init_file = CPP_XSTR(E_INITFILE);
 
     if (strlen(init_file)) {
+        // Note: not lisp_eval()'ing it, because we want to have consistent error handling.
         eval_string(true, "(load \"%s\")", init_file);
         close_eval();
     }
@@ -82,7 +83,7 @@ char *eval_string(int do_format, char *format, ...)
     }
 
     flisp_interp->output = file_fopen(flisp_interp, "", ">");
-    if ((result = lisp_eval(flisp_interp, input)))
+    if ((result = lisp_eval_string(flisp_interp, input)))
         msg("error: %s", flisp_interp->message);
     if (debug_mode) {
         if (result)

--- a/main.c
+++ b/main.c
@@ -40,12 +40,18 @@ int main(int argc, char **argv)
     if (flisp_interp == NULL)
         fatal("fLisp initialization failed");
 
+    if (debug_mode)
+        // Note: file_fopen can raise IO exception, 
+        flisp_interp->debug = file_fopen(flisp_interp, "debug.out", "a");
+    
     if ((init_file = getenv("FEMTORC")) == NULL)
         init_file = CPP_XSTR(E_INITFILE);
 
-    if (lisp_eval(flisp_interp, "(load \"%s\")", init_file))
-        msg(flisp_interp->message);
-
+    if (strlen(init_file)) {
+        eval_string(true, "(load \"%s\")", init_file);
+        close_eval();
+    }
+    
     /* GUI */
     if (!batch_mode) gui();
 
@@ -53,6 +59,46 @@ int main(int argc, char **argv)
     // Note: exit frees all memory, do we need this here?
     if (scrap != NULL) free(scrap);
     return 0;
+}
+
+char *eval_string(int do_format, char *format, ...)
+{
+    ResultCode result;
+    char buf[INPUT_FMT_BUFSIZ], *input;
+    int size;
+    va_list args;
+
+    if (do_format) {
+        va_start(args, format);
+        size = vsnprintf (buf, sizeof(buf), format, args);
+        va_end(args);
+        if (size > INPUT_FMT_BUFSIZ) {
+            msg("input string larger then %d", INPUT_FMT_BUFSIZ);
+            return NULL;
+        }
+        input = buf;
+    } else {
+        input = format;
+    }
+
+    flisp_interp->output = file_fopen(flisp_interp, "", ">");
+    if ((result = lisp_eval(flisp_interp, input)))
+        msg("error: %s", flisp_interp->message);
+    if (debug_mode) {
+        if (result)
+            debug("error: %s\n", flisp_interp->message);
+        debug(flisp_interp->output->buf);
+    }
+    if (result) {
+        close_eval();
+        return NULL;
+    }
+    return flisp_interp->output->buf;
+}
+void close_eval()
+{
+    if (file_fclose(flisp_interp, flisp_interp->output))
+        debug("error: closing output stream");
 }
 
 void gui()

--- a/makefile
+++ b/makefile
@@ -23,8 +23,15 @@ INITFILE = "$(SCRIPTDIR)/femto.rc"
 
 OBJ     = command.o display.o complete.o data.o gap.o key.o search.o buffer.o replace.o window.o undo.o funcmap.o utils.o hilite.o lisp.o main.o
 
+FLISP_OBJ = flisp.o lisp.o
+
+all: femto doc/flisp.md
+
 femto: $(OBJ)
 	$(LD) $(LDFLAGS) -o femto $(OBJ) $(LIBS)
+
+flisp: $(FLISP_OBJ)
+	$(LD) $(LDFLAGS) -o $@ $(FLISP_OBJ)
 
 complete.o: complete.c header.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c complete.c
@@ -76,6 +83,9 @@ main.o: main.c header.h lisp.h
 	  -D E_SCRIPTDIR=$(SCRIPTDIR) \
 	  -D E_INITFILE=$(INITFILE) \
 	  -c main.c
+
+flisp.o: flisp.c lisp.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
 
 docs/flisp.md: pdoc/flisp.html pdoc/h2m.lua
 	pandoc -o $@ -t gfm -L pdoc/h2m.lua $<

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ femto: $(OBJ)
 complete.o: complete.c header.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c complete.c
 
-command.o: command.c header.h
+command.o: command.c header.h lisp.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c command.c
 
 data.o: data.c header.h
@@ -59,7 +59,7 @@ buffer.o: buffer.c header.h
 undo.o: undo.c header.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c undo.c
 
-funcmap.o: funcmap.c header.h
+funcmap.o: funcmap.c header.h lisp.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c funcmap.c
 
 utils.o: utils.c header.h
@@ -71,7 +71,7 @@ hilite.o: hilite.c header.h
 lisp.o: lisp.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c lisp.c
 
-main.o: main.c header.h
+main.o: main.c header.h lisp.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) \
 	  -D E_SCRIPTDIR=$(SCRIPTDIR) \
 	  -D E_INITFILE=$(INITFILE) \

--- a/makefile
+++ b/makefile
@@ -27,6 +27,9 @@ FLISP_OBJ = flisp.o lisp.o
 
 BINARIES = femto flisp
 
+LISPFILES = femto.rc lisp/defmacro.lsp lisp/bufmenu.lsp lisp/dired.lsp lisp/grep.lsp lisp/git.lsp lisp/oxo.lsp \
+	lisp/flisp.lsp lisp/femto.lsp lisp/info.lsp
+
 all: femto docs/flisp.md
 
 femto: $(OBJ)
@@ -91,6 +94,21 @@ main.o: main.c header.h lisp.h
 
 flisp.o: flisp.c lisp.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
+
+measure: strip FORCE
+	@echo Total
+	@echo binsize: $$(set -- $$(ls -l femto); echo $$5)
+	@echo linecount: $$(cat *.c *.h *.rc lisp/*.lsp | wc -l)
+	@echo sloccount: $$(set -- $$(which sloccount >/dev/null && { sloccount *.c *.h *.rc lisp/*.lsp | grep ansic=; }); echo $$3)
+	@echo files: $$(ls *.c *.h *.rc lisp/*.lsp | wc -l)
+	@echo C-files: $$(ls *.c *.h | wc -l)
+	@echo Minimum
+	@echo linecount: $$(cat *.c *.h $(LISPFILES) | wc -l) 
+	@echo sloccount: $$(set -- $$(which sloccount >/dev/null && { sloccount *.c *.h *.rc $(LISPFILES) | grep ansic=; }); echo $$3)
+	@echo files: $$(ls *.c *.h $(LISPFILES) | wc -l) 
+
+strip: femto FORCE
+	strip femto
 
 docs/flisp.md: pdoc/flisp.html pdoc/h2m.lua
 	pandoc -o $@ -t gfm -L pdoc/h2m.lua $<

--- a/makefile
+++ b/makefile
@@ -77,8 +77,8 @@ main.o: main.c header.h
 	  -D E_INITFILE=$(INITFILE) \
 	  -c main.c
 
-docs/flisp.md: pdoc/flisp.html
-	pandoc -o $@ -t gfm $<
+docs/flisp.md: pdoc/flisp.html pdoc/h2m.lua
+	pandoc -o $@ -t gfm -L pdoc/h2m.lua $<
 
 README.html: README.md
 	pandoc -o $@ -f gfm $<

--- a/makefile
+++ b/makefile
@@ -21,11 +21,13 @@ DATADIR = $(PREFIX)/share
 SCRIPTDIR = "$(DATADIR)/femto"
 INITFILE = "$(SCRIPTDIR)/femto.rc"
 
-OBJ     = command.o display.o complete.o data.o gap.o key.o search.o buffer.o replace.o window.o undo.o funcmap.o utils.o hilite.o lisp.o main.o
+OBJ     = command.o display.o complete.o data.o gap.o key.o search.o buffer.o replace.o window.o undo.o funcmap.o utils.o hilite.o femto_lisp.o main.o
 
 FLISP_OBJ = flisp.o lisp.o
 
-all: femto doc/flisp.md
+BINARIES = femto flisp
+
+all: femto docs/flisp.md
 
 femto: $(OBJ)
 	$(LD) $(LDFLAGS) -o femto $(OBJ) $(LIBS)
@@ -66,6 +68,9 @@ buffer.o: buffer.c header.h
 undo.o: undo.c header.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c undo.c
 
+femto_lisp.o: lisp.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -D FLISP_FEMTO_EXTENSION -c lisp.c -o $@
+
 funcmap.o: funcmap.c header.h lisp.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c funcmap.c
 
@@ -76,7 +81,7 @@ hilite.o: hilite.c header.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c hilite.c
 
 lisp.o: lisp.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c lisp.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -D FLISP_FILE_EXTENSION -c lisp.c
 
 main.o: main.c header.h lisp.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) \
@@ -105,7 +110,7 @@ run: femto FORCE
 	FEMTORC=femto.rc FEMTOLIB=lisp FEMTO_DEBUG=1  ./femto
 
 clean: FORCE
-	-$(RM) -f $(OBJ) femto
+	-$(RM) -f $(OBJ) $(FLISP_OBJ) $(BINARIES)
 	-$(RM) -rf doxygen
 	-$(RM) -f docs/flisp.md README.html
 

--- a/makefile
+++ b/makefile
@@ -91,6 +91,9 @@ doxygen: FORCE
 test: femto FORCE
 	(cd test && ./run)
 
+run: femto FORCE
+	FEMTORC=femto.rc FEMTOLIB=lisp FEMTO_DEBUG=1  ./femto
+
 clean: FORCE
 	-$(RM) -f $(OBJ) femto
 	-$(RM) -rf doxygen

--- a/pdoc/flisp.html
+++ b/pdoc/flisp.html
@@ -1,462 +1,670 @@
 <!DOCTYPE html>
 <html lang="en" xml:lang="en">
-<head>
-	<title>fLisp Manual</title>
-	<meta content="text/html; charset=utf-8" http-equiv="content-type" /><meta content="Emacs, editor, Lisp, tiny, reference, manual" name="keywords" /><meta content="Reference and user manual for the fLisp programming language and interpreter" name="description" /><meta content="Georg Lehner &lt;jorge@magma-soft.at&gt;" name="author" /><meta content="2023" name="copyright" />
-</head>
-<body>
-<h1>fLisp Manual</h1>
-
-<h3>Introduction</h3>
-
-<p><i>fLisp</i> is a tiny yet practical interpreter for a dialect of the Lisp programming language. It is used as extension language for the <a href="https://github.com/matp/tiny-lisp">Femto</a> text editor.</p>
-
-<p><i>fLisp</i>&nbsp;originates from <a href="https://github.com/matp/tiny-lisp">Tiny-Lisp by matp </a>(pre 2014), was integrated into <a href="https://github.com/hughbarney/femto">Femto</a> by Hugh Barnes (pre 2016) and compacted by Georg Lehner in 2023.</p>
-
-<blockquote>
-<p>A designer knows he has achieved perfection not when there is nothing left to add, but when there is nothing left to take away.</p>
-
-<p>&mdash; Antoine de Saint-Exupery</p>
-</blockquote>
-
-<h3>Lisp</h3>
-
-<h4>Notation Convention</h4>
-
-<p>fLisp fancies to converge toward Emacs Lisp. Functions descriptions are annoted with a compatibility scale:</p>
-
-<dl>
-	<dt><u>C</u></dt>
-	<dd>Interface compatible, though probably less featureful.</dd>
-	<dt><u>D</u></dt>
-	<dd>Same name, but different behavior.</dd>
-	<dt><u>S: <var>name</var></u></dt>
-	<dd><var>name</var> is a similar but not compatible function in Emacs Lisp.</dd>
-	<dt><u>B</u></dt>
-	<dd>Buggy/incompatible implementation.</dd>
-</dl>
-
-<p>Annotation is omitted if the function does not exist in Emacs Lisp.</p>
-
-<h4>fLisp Interpreter</h4>
-
-<p>When <i>fLisp</i> is invoked it follows a three step process:</p>
-
-<ol>
-	<li>Read: program text is read in and converted into an internal representation.</li>
-	<li>Evaluate: the internal representation is evaluated</li>
-	<li>Print: the result of the evaluation is returned to the invoker.</li>
-</ol>
-
-<p>Core functions of the language operate on internal objects only. The interpreter is extended with additional functions in order to interact with external objects.&nbsp; With respect to the interpreter, extension functions behave the same as core functions.</p>
-
-<h4>Syntax</h4>
-
-<p>Program text is written as a sequence of symbolic expressions - <abbr><dfn>sexp</dfn></abbr>&#39;s in parenthesized form. A sexp is either a&nbsp;single object or a function invocation enclosed in parens. Function invocations can be infinitely nested.</p>
-
-<p>The following characters are special to the reader:</p>
-
-<dl>
-	<dt><code>(</code></dt>
-	<dd>Starts a function invocation, <i>list</i> or <i>cons</i> object (see &quot;Objects and Data Types&quot;).<br />
-	&nbsp;</dd>
-	<dt><code>)</code></dt>
-	<dd>Finishes a function invocation, <i>list</i> or <i>cons</i> object.<br />
-	&nbsp;</dd>
-	<dt><code>&quot;</code></dt>
-	<dd>Encloses strings.<br />
-	&nbsp;</dd>
-	<dt><code>&#39;</code></dt>
-	<dd>With a single quote prefix before a <i>sexp</i>, the <i>sexp</i> is expanded to <code>(quote <var>sexp</var>)</code> before it is evaluated.</dd>
-	<dt><code>.</code></dt>
-	<dd>The expresion<code> (<var>a</var> . <var>b</var>)</code>&nbsp;evaluates to a <i>cons</i> object, holding the objects <var>a</var> and <var>b</var>.</dd>
-</dl>
-
-<p>Numbers are represented in decimal notation.</p>
-
-<p>A list of objects has the form:</p>
-
-<blockquote>
-<p><code><font face="monospace">(</font></code><font face="monospace">[</font><code><font face="monospace"><var>element</var></font></code><font face="monospace"> ..]</font><code><font face="monospace">)</font></code></p>
-</blockquote>
-
-<p>A function invocation has the form:</p>
-
-<blockquote>
-<p><code>(<var>name</var> </code>[<code><var>param</var> </code>..]<code>)</code></p>
-</blockquote>
-
-<p>There are two predefined objects. Their symbols are:</p>
-
-<dl>
-	<dt><code>nil</code></dt>
-	<dd>represents:&nbsp;the empty list:&nbsp;(),&nbsp;the end of a list marker or&nbsp;the false value in logical operations.<br />
-	&nbsp;</dd>
-	<dt><code>t</code></dt>
-	<dd>a fixed, non-false&nbsp;value.</dd>
-</dl>
-
-<h4>Objects and Data Types</h4>
-
-<p><i>fLisp</i> objects have exactly one of the following data types:</p>
-
-<dl>
-	<dt><dfn>number</dfn></dt>
-	<dd><a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format">double precision floating point number.</a></dd>
-	<dt><dfn>string</dfn></dt>
-	<dd>character array.</dd>
-	<dt><dfn>cons</dfn></dt>
-	<dd>object holding two pointers to objects.</dd>
-	<dt><dfn>symbol</dfn></dt>
-	<dd>string with restricted character set: <code>[A-Z][0-9][a-z]!#$%&amp;*+-./:&lt;=&gt;?@^_~</code></dd>
-	<dt><dfn>lambda</dfn></dt>
-	<dd>anonymous function with parameter evaluation</dd>
-	<dt><dfn>macro</dfn></dt>
-	<dd>anonymous function without parameter evaluation</dd>
-</dl>
-
-<p>Objects are unmutable, all fLisp functions create new objects from existing ones.</p>
-
-<p>Characters do not have their own type. A single character is represented by a <i>string</i> with length 1.</p>
-
-<h4>Symbols, Environments and Functions</h4>
-
-<p>All operations of the interpreter take place in a root environment. An <dfn>environment</dfn> is a collection of named objects. The object names have the <var>symbol</var> datatype.</p>
-
-<p><var>lambda</var> and <var>macro</var> objects are functions. They have a parameter list and a body. When they are invoked, they receive zero or more named objects, bind them one by one to the symbols in the paramter list, evaluate the body and return a result.</p>
-
-<p>When a function executed within the function body want&#39;s to use a named object it is first looked up in the new environment, and then recursively in the environments from which the <var>lambda</var>&nbsp;or <var>macro</var> was invoked.</p>
-
-<p><var>lambda</var>s evaluate each parameter then create a new environment containing the parameters before evaluating the body.</p>
-
-<p><i>macros</i> evaluate the body which typically returns a new expresions in terms of the parameters. The expression is then evaluated in a new environment containing the parameters.</p>
-
-<h4>Functions</h4>
-
-<h5>Interpreter</h5>
-
-<dl>
-	<dt><code>(progn</code> [<code><var>expr</var></code> ..]<code>)</code></dt>
-	<dd>Each <var>expr</var> is evaluated, the value of the last is returned.<br />
-	&nbsp;</dd>
-	<dt><code>(cond</code> [<code><var>clause</var></code> ..]<code>)</code></dt>
-	<dd>Each <var>clause</var> is of the form <code>(<var>pred</var> [<var>action</var>])</code>. <code>cond</code> evaluates each <var>clause</var> in turn:&nbsp;if <var>pred</var> evaluates to <code>nil</code>, the next <var>clause</var> is tested. Otherwise: if there is no <var>action</var> the value of <var>pred</var> is returned, otherwise <code>(progn <var>action</var>)</code> is returned and no more <var>clause</var>s are evaluated.</dd>
-	<dt><code>(setq <var>symbol</var> <var>value</var></code> [<code><var>symbol</var> <var>value</var></code>]..<code>)</code></dt>
-	<dd>Create or update named objects: If <var>symbol</var> is the name of an existing named object in the current or a parent environment the named object is set to <var>value</var>, if no symbol with this name exists, a new one is created in the current environment. <code>setq</code> returns the last <var>value</var>.</dd>
-	<dt><code>(lambda&nbsp;<var>params</var> <var>body</var>)</code></dt>
-	<dd>Returns a <var>lambda</var> function which accepts 0 or more arguments, which are passed as list in the parameter <var>params</var>.</dd>
-	<dt><code>(lambda (</code>[<code><var>param</var></code> ..]<code>) <var>body</var>)</code></dt>
-	<dd>Returns a <var>lambda</var> function which accepts the exact number of arguments given in the list of&nbsp;<var>param</var>s.</dd>
-	<dt><code>(lambda (<var>param</var></code> [<code><var>param</var></code> ..]<code> . opt)</code></dt>
-	<dd>Returns a <var>lambda</var> function which requires at least the exact number of arguments given in the list of <var>param</var>s. All extra arguments are passed as a list in the parameter <var>opt</var>.</dd>
-	<dt><code>(macro&nbsp;<var>params</var> <var>body</var>)</code></dt>
-	<dd>
-	<p>These forms return a <var>macro</var> function with the same parameter handling as with <var>lambda</var>.</p>
-	</dd>
-	<dt><code>(macro (</code>[<code><var>param</var></code> ..]<code>) <var>body</var>)</code></dt>
-	<dd>
-	<p>-</p>
-	</dd>
-	<dt><code>(macro (<var>param</var></code> [<code><var>param</var></code> ..]<code> . opt)</code></dt>
-	<dd>
-	<p>-</p>
-	</dd>
-	<dt><code>(quote <var>expr</var>)</code></dt>
-	<dd>quote returns <var>expr</var>&nbsp;without evaluating it.<br />
-	&nbsp;</dd>
-	<dt>(signal symbol list)</dt>
-	<dd>tbd</dd>
-	<dt>(trap list)</dt>
-	<dd>tbd</dd>
-	<dt>&nbsp;</dt>
-	<dd>&nbsp;</dd>
-</dl>
-
-<h5>Objects</h5>
-
-<dl>
-	<dt><code>(null <var>object</var>)</code></dt>
-	<dd>Returns <code>t</code> if <var>object</var>&nbsp;is&nbsp;<code>nil</code>, otherwise <code>nil</code>.</dd>
-	<dt><code>(symbolp <var>object</var>)</code><span style="display: none;">&nbsp;</span><span style="display: none;">&nbsp;</span></dt>
-	<dd>Returns <code>t</code> if <var>object</var> is of type <i>symbol,&nbsp;</i>otherwise <code>nil</code>.</dd>
-	<dt><code>(symbol-name <var>object</var>)</code></dt>
-	<dd>If <var>object</var> is of type <i>symbol</i> return its value as string.</dd>
-	<dt><code>(numberp <var>object</var>)</code></dt>
-	<dd>Returns <code>t</code> if <var>object</var> is of type <i>number</i>,&nbsp;otherwise <code>nil</code>.</dd>
-	<dt><code>(stringp <var>object</var>)</code> Returns <code>t</code> if <var>object</var> is of type <i>string</i>, otherwise <code>nil</code>.</dt>
-	<dd>&nbsp;</dd>
-	<dt><code>(consp <var>object</var>)</code></dt>
-	<dd>Returns <code>t</code> if <var>object</var> is of type <i>cons</i>, otherwise <code>nil</code>.</dd>
-	<dt><code>(cons <var>car</var> <var>cdr</var>)</code></dt>
-	<dd>Returns a new <i>cons</i> with the first object set to the value of <var>car</var> and the second to the value of <var>cdr</var>.</dd>
-	<dt><code>(car <var>cons</var>)</code></dt>
-	<dd>Returns the first object of <var>cons</var>.</dd>
-	<dt><code>(cdr <var>cons</var>)</code></dt>
-	<dd>Returns the second object of <var>cons</var>.</dd>
-	<dt><code>(eq <var>a</var> <var>b</var>)</code></dt>
-	<dd>Returns <code>t</code> if <var>a</var> and <var>b</var> evaluate to the same object, <code>nil</code> otherwise.</dd>
-	<dt><code>(print <var>object</var>)</code></dt>
-	<dd>Formats <var>object</var> into a string which can be read by the reader and returns it. As a side effect, the string is printed to the output stream with a leading and a closing newline.&nbsp;<code>print</code> escapes quotes in strings with a backslash.</dd>
-	<dt><code>(princ <var>object</var>)</code></dt>
-	<dt>Formats <var>object</var> into a string and returns it, As a side effect, the string is printed to the output stream.</dt>
-</dl>
-
-<h5>String operations</h5>
-
-<dl>
-	<dt><code>(string.length <var>string</var>)</code></dt>
-	<dd>Returns the length of <var>string</var> as a <i>number</i>.</dd>
-	<dd>&nbsp;</dd>
-	<dt><code>(string.substring <var>string</var> <var>start</var> <var>end</var>)</code></dt>
-	<dd>Returns the substring from <var>string</var> which starts with the character&nbsp;at index <var>start</var> and ends with index <var>end</var>. String indexes are zero based.</dd>
-	<dt><code>(string.append <var>string1</var> <var>string2</var>)</code></dt>
-	<dd>Returns a new string consisting of the concatenation of <var>string1</var> with <var>string2</var>.<br />
-	&nbsp;</dd>
-	<dt><code>(string-to-number <var>string</var>)</code></dt>
-	<dd>Converts <var>string</var> into a corresponding <i>number</i> object. String is interpreted as decimal based integer.</dd>
-	<dt><var><code>(number-to-string number)</code></var></dt>
-	<dd>Converts <var>number</var> into a <i>string</i> object.<br />
-	&nbsp;</dd>
-	<dt><code>(ascii <var>number</var>)</code></dt>
-	<dd>Converts <var>number</var> into a <i>string</i> with one character, which corresponds to the ASCII representation of <var>number</var>.<br />
-	&nbsp;</dd>
-	<dt><code>(ascii-&gt;number <var>string</var>)</code></dt>
-	<dd>Converts the first character of <var>string</var> into a <i>number</i> which corresponds to its&nbsp;ASCII value.</dd>
-	<dt>&nbsp;</dt>
-</dl>
-
-<h5>Arithmetic Operations</h5>
-
-<dl>
-	<dt><code>(+</code> [<code><var>arg</var></code>&nbsp;..]<code>)</code></dt>
-	<dd>Returns the sum of all <var>arg</var>s or&nbsp;<code>0</code>&nbsp;if none given.</dd>
-	<dt><code>(*</code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>Returns the product of all <var>arg</var>s or <code>1</code> if none given.</dd>
-	<dt><code>(-</code> [<code><var>arg</var></code>&nbsp;..]<code>)</code></dt>
-	<dd>Returns 0 if no <var>arg</var> is given, -<var>arg</var> if only one is given,&nbsp;<var>arg</var> minus the sum of all others&nbsp;otherwise.</dd>
-	<dt><code>(/ <var>arg</var></code> [<code><var>div</var></code> ..]<code>)</code></dt>
-	<dd>Returns 1/<var>arg</var> if no <var>div</var> is given, <var>arg</var>/<var>div</var>[/<var>div</var>../] if one or more <var>div</var>s are given, <code>inf</code> if one of the <var>div</var>s is <code>0</code> and the sum of the signs of all operands is even, <code>-inf</code> if it is odd.</dd>
-	<dt><code>(% <var>arg</var></code> [<code><var>div</var></code> ..]<code>)</code></dt>
-	<dd>Returns <code>1</code> if no <var>div</var> is given, <var>arg</var>%<var>div</var>[%<var>div</var> ..] if one or more <var>div</var>s are given. If one of the divs is <code>0</code>, the program exits with an arithmetic&nbsp;exception.</dd>
-	<dt><code>(= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>-<br />
-	&nbsp;</dd>
-	<dt><code>(&lt;&nbsp;<var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>-<br />
-	&nbsp;</dd>
-	<dt><code>(&gt;&nbsp;<var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>-<br />
-	&nbsp;</dd>
-	<dt><code>(&lt;= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>-<br />
-	&nbsp;</dd>
-	<dt><code>(&gt;= <var>arg</var></code> [<code><var>arg</var></code> ..]<code>)</code></dt>
-	<dd>These predicate functions apply&nbsp;the respective comparison operator between all <var>arg</var>s and return the respective result as <code>t</code> or <code>nil</code>.</dd>
-</dl>
-
-<h3>Editor Extensions</h3>
-
-<h4>Buffers</h4>
-
-<p>Buffers store text and allow to manipulate it. A buffer has the following properties:</p>
-
-<dl>
-	<dt><var>Name</var></dt>
-	<dd>Buffers are identified by their name. If a buffer name is enclosed in *asterisks* the buffer receives special treatment.</dd>
-	<dt><var>Text</var></dt>
-	<dd>0 or more characters.</dd>
-	<dt><var>Point</var></dt>
-	<dd>The position&nbsp;in the text where text manipulation takes place.</dd>
-	<dt><var>Mark</var></dt>
-	<dd>An optional second position in the text. If the <var>mark</var> is set, the text between <var>point</var> and <var>mark</var> is called the <dfn>selection</dfn>&nbsp;or <dfn>region</dfn>.</dd>
-	<dt><var>Filename</var></dt>
-	<dd>A buffer can be associated with a file.</dd>
-	<dt><var>Flags</var></dt>
-	<dd>Different flags determine the behaviour of the buffer.</dd>
-</dl>
-
-<p>This section describes the buffer related functions added by Femto to fLisp. The description is separated in function related to buffer management and text manipulation. Buffer management creates, deletes buffers, or selects one of the existing buffers as the <q>current</q> buffer. Text manipulation always operates on the&nbsp;current buffer.</p>
-
-<p>Femto provides a single temporary string storage named <dfn>clipboard</dfn>&nbsp;to support text manipulation.</p>
-
-<h5>Text manipulation</h5>
-
-<dl>
-	<dt><code>(insert-string <var>string</var>)</code></dt>
-	<dd>Inserts&nbsp;<var>string</var> at <i>point</i>. <u>S: insert</u>.</dd>
-	<dt><code>(insert-file-contents-literally <var>string</var>&nbsp;</code>[<code><var>flag</var></code>]<code>)</code></dt>
-	<dd>
-	<p>Inserts the file <var>string</var>&nbsp;after&nbsp;<i>point</i>. If <var>flag</var> is not nil the buffer is marked as not modified. <u>B</u></p>
-	</dd>
-	<dd>
-	<p>Note: Currently the flag is forced to nil. The function should return <code>(<var>filename</var> <var>count</var>)</code>&nbsp;but it returns a flag indicating if the operation succeeded.</p>
-	</dd>
-	<dt><code>(erase-buffer)</code></dt>
-	<dd>Erases all text in&nbsp;the current buffer. <u>C</u></dd>
-	<dt><code>(delete)</code></dt>
-	<dd>Deletes the character after <i>point</i>. <u>S: delete-char</u></dd>
-	<dt><code>(backspace)</code></dt>
-	<dd>Deletes the character to the left of <i>point</i>. <u>S:&nbsp;delete-backward-char</u></dd>
-	<dt><code>(get-char)</code></dt>
-	<dd>Returns the character to the left of <i>point</i>. <u>S:&nbsp;get-byte</u></dd>
-	<dt><code>(copy-region)</code></dt>
-	<dd>Copies&nbsp;<i>region</i> to&nbsp;the <i>clipboard</i>. <u>S:&nbsp;copy-region-as-kill</u></dd>
-	<dt><code>(kill-region)</code></dt>
-	<dd>Deletes the text in&nbsp;the <i>region</i> and copies&nbsp;it to the <i>clipboard</i>. <u>D</u></dd>
-	<dt><code>(yank)</code></dt>
-	<dd>Pastes the <i>clipboard</i>&nbsp;before <i>point</i>. <u>C</u></dd>
-</dl>
-
-<h5>Selection</h5>
-
-<dl>
-	<dt>(set-mark)</dt>
-	<dd>Sets <var>mark</var> to <var>point</var>. <u>D</u></dd>
-	<dt>(get-mark)</dt>
-	<dd>Returns the position of <var>mark</var>, -1 if <var>mark</var> is unset. <u>S: mark</u></dd>
-	<dt>(get-point)</dt>
-	<dd>Returns the position of <var>point</var>. <u>S: point</u></dd>
-	<dt>(get-point-max)</dt>
-	<dd>Returns the maximum accessible value of point in the current buffer. <u>S: point-max</u></dd>
-	<dt><code>(set-clipboard <var>variable</var>)</code></dt>
-	<dd><code>Sets <i>clipboard</i> to the contents of <var>variable</var>.</code>&nbsp;<u>S:&nbsp;gui-set-selection</u></dd>
-	<dt><code>(get-clipboard)</code></dt>
-	<dd>Returns the <i>clipboard</i> contents.&nbsp;&nbsp;<u>S:&nbsp;gui-get-selection</u></dd>
-</dl>
-
-<h5>Cursor Movement</h5>
-
-<dl>
-	<dt><code>(set-point <var>number</var>)</code></dt>
-	<dd>Sets the point to in the current buffer to the position <var>number</var>. <u>S: goto-char</u></dd>
-	<dt><code>(goto-line <var>number</var>)</code></dt>
-	<dd>Sets the point in the current buffer to the first character on line <var>number</var>. <u>S: goto-line</u>, not an Elisp function.</dd>
-	<dt><code>(search-forward <var>string</var>)</code></dt>
-	<dd>Searches for <var>string</var> in the current buffer, starting from point forward. If string is found, sets the point after the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone and returns <samp>nil</samp>. <u>D</u></dd>
-	<dt><code>(search-backward <var>string</var>)</code></dt>
-	<dd>Searches for <var>string</var> in the current buffer, starting from point backwards. If string is found, sets the point before the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone and returns <samp>nil</samp>. <u>D</u></dd>
-	<dt><code>(beginning-of-buffer)</code></dt>
-	<dd>Sets the point in the current buffer to the first buffer position, leaving mark in its current position. <u>C</u></dd>
-	<dt><code>(end-of-buffer)</code></dt>
-	<dd>Sets the point in the current buffer to the last buffer position, leaving mark in its current position. <u>C</u></dd>
-	<dt><code>(beginning-of-line)</code></dt>
-	<dd>Sets point before the first character of the current line, leaving mark in its current position. <u>S: move-beginning-of-line</u></dd>
-	<dt><code>(end-of-line)</code></dt>
-	<dd>Sets point after the last character of the current line, i.e. before the end-of-line character sequence, leaving mark in its current position. <u>S: move-end-of-line</u></dd>
-	<dt><code>(forward-word)</code></dt>
-	<dd>Moves the point in the current buffer forward before the first char of the next word. If there is no word left the point is set to the end of the buffer. If the point is already at the start or within a word, the current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>end</em> of the the next word.</dd>
-	<dt><code>(backward-word)</code></dt>
-	<dd>Moves the point in the current buffer backward after the last char of the previous word. If there is no word left the point is set to the beginning of the buffer. If the point is already at the end or within a word, the current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>beginning</em> of the previous word.</dd>
-	<dt><code>(forward-char)</code></dt>
-	<dd>Moves the point in the current buffer one character forward, but not past the end of the buffer. <u>C</u></dd>
-	<dt><code>(backward-char)</code></dt>
-	<dd>Moves the point in the current buffer one character backward, but not before the end of the buffer. <u>C</u></dd>
-	<dt><code>(forward-page)</code></dt>
-	<dd>Moves the point of the current buffer to the beginning of the last visible line of the associated screen and scrolls the screen up to show it as the first line. <u>S: scroll-up</u></dd>
-	<dt><code>(backward-page)</code></dt>
-	<dd>Moves the point of the current buffer to the beginning of the first visible line of the associoated screen and scrolls the screen down to show it as the last line. <u>S: scroll-down</u></dd>
-	<dt><code>(next-line)</code></dt>
-	<dd>Moves the point in the current buffer to the same character position in the next line, or to the end of the next line if there are not enough characters. In the last line of the buffer moves the point to the end of the buffer. <u>C</u></dd>
-	<dt><code>(previous-line)</code></dt>
-	<dd>Movest the point in the current buffer to the same character position in the previous line, or to the end of the previous line if there are not enough characters. In the first line of the buffer the point is not moved. <u>C</u></dd>
-</dl>
-
-<h5>Buffer management</h5>
-
-<dl>
-	<dt><code>(list-buffers)</code></dt>
-	<dd>Lists all the buffers in a buffer called <samp>*buffers*</samp>.</dd>
-	<dt><code>(get-buffer-count)</code></dt>
-	<dd>Returns the number of buffers, includes all special buffers and <samp>*buffers*</samp>.</dd>
-	<dt><code>(select-buffer <var>string</var>)</code></dt>
-	<dd>Makes the buffer named <var>string</var> the current buffer. Note: <u>C</u> to <code>set-buffer</code> in Elisp.</dd>
-	<dt><code>(rename-buffer <var>string</var>)</code></dt>
-	<dd>Rename the current buffer to <var>string</var>. <u>C</u></dd>
-	<dt><code>(kill-buffer <var>string</var>)</code></dt>
-	<dd>Kill the buffer names <var>string</var>. Unsaved changes are discarded. <u>C</u></dd>
-	<dt><code>(get-buffer-name)</code></dt>
-	<dd>Return the name of the current buffer. Note: <u>C</u> to <code>buffer-name</code> in Elisp.</dd>
-	<dt><code>(add-mode-global <var>string</var>)</code></dt>
-	<dd>Sets global mode&nbsp;<var>string</var> for all buffers. Currently the only global mode is <kbd>undo</kbd>.</dd>
-	<dt><code>(find-file <var>string</var>)</code></dt>
-	<dd>Loads file with path string into a new buffer. <u>C</u></dd>
-	<dt><code>(save-buffer <var>string</var>)</code></dt>
-	<dd>Saves the buffer named <var>string</var> to disk. <u>C</u></dd>
-</dl>
-
-<h4>User Interaction</h4>
-
-<dl>
-	<dt><code>(message <var>string</var>)</code></dt>
-	<dd>Displays&nbsp;<var>string</var> in the message line. <u>D</u>&nbsp;</dd>
-	<dt><code>(clear-message-line)</code></dt>
-	<dd>Displays the empty string in the message line.</dd>
-	<dt><code>(prompt <var>prompt</var> <var>default</var>)</code></dt>
-	<dd>Displays&nbsp;<var>prompt</var> in the command line and sets <var>default</var> as initial value for the user respones. The user can edit the response. When hitting return, the final response is returned.</dd>
-	<dt><code>(show-prompt <var>prompt</var> <var>default</var>)</code></dt>
-	<dd>Displays <var>prompt</var> and <var>default</var> in the commandline, but does not allow editing. Returns <samp>t</samp>.</dd>
-	<dt><code>(prompt-filename <var>prompt</var>)</code></dt>
-	<dd>Displays <var>prompt</var> in the commandline and allows to enter or search for a file name. Returns the relative path to the selected file name or the response typed by the user.</dd>
-	<dt><code>(getch)</code></dt>
-	<dd>Waits for a key to be pressed and returns the key as string. See also <code>get-key-name</code>, <code>get-key-funcname</code> and <code>execute-key</code>.</dd>
-	<dt>(exit)</dt>
-	<dd>Exit Femto without saving modified buffers.</dd>
-</dl>
-
-<h5>Keyboard Handling</h5>
-
-<dl>
-	<dt><code>(set-key <var>key-name</var> <var>lisp-func</var>)</code></dt>
-	<dd>Binds key key-name to the lisp function <var>lisp-func</var>.</dd>
-	<dt><code>(get-key-name)</code></dt>
-	<dd>Returns the name of the currently pressed key, eg: <samp>c-k</samp> for control-k.</dd>
-	<dt><code>(get-key-funcname)</code></dt>
-	<dd>Return the name of the function bound to the currently pressed key.</dd>
-	<dt><code>(execute-key)</code></dt>
-	<dd>Executes the function of the last bound key. <mark>Tbd.&nbsp;bound or pressed?</mark></dd>
-	<dt><code>(describe-bindings)</code></dt>
-	<dd>Creates a listing of all current key bindings, in a buffer named <samp>*help*</samp> and displays it in a new window. <u>C</u></dd>
-	<dt><code>(describe-functions)</code></dt>
-	<dd>Creates a listing of all functions bound to keys in a buffer named <samp>*help*</samp> and displays it in a new window.</dd>
-</dl>
-
-<h5>Window Handling</h5>
-
-<dl>
-	<dt><code>(delete-other-windows)</code></dt>
-	<dt>&nbsp;Make current window the only window. <u>C</u></dt>
-	<dd>&nbsp;</dd>
-	<dt><code>(split-window)</code></dt>
-	<dd>Splits the current window. Creates a new window for the current buffer. <u>C</u></dd>
-	<dt><code>(other-window)</code></dt>
-	<dd>Moves the cursor to the next window down on the screen. Makes the buffer in that window the current buffer. <u>D</u></dd>
-	<dd>Note: Elisp <code>other-window</code> has a required parameter <var>count</var>, which specifies the number of windows to move down or up.</dd>
-	<dt><code>(update-display)</code></dt>
-	<dd>Updates all modified windows.</dd>
-	<dt><code>(refresh)</code></dt>
-	<dd>Updates all windows by marking them modified and calling <code>update-display</code>.</dd>
-</dl>
-
-<h5>Programming and System Interaction</h5>
-
-<dl>
-	<dt><code>(eval-block)</code></dt>
-	<dd>Evaluates the <var>region</var> in the current buffer, inserts the result at <var>point</var> and returns it. If <var>mark</var> in the current buffer is before <var>point</var> <code>eval-block</code> evaluates this <var>region</var>&nbsp;and inserts the result at <var>point</var>. If <var>point</var> is before <var>mark</var> <code>eval-block</code> does nothing but returning <samp>t</samp>.</dd>
-	<dt><code>(system <var>string</var>)</code></dt>
-	<dd>Executes the <a href="https://man7.org/linux/man-pages/man3/system.3.html">system(1)</a> function with <var>string</var> as parameter.</dd>
-	<dt><code>(os.getenv <var>string</var>) </code></dt>
-	<dd>Returns the value of the environment variable named <var>string</var>.</dd>
-	<dt><code>(log-message <var>string</var>)</code></dt>
-	<dd>Logs <var>string</var> to the <samp>*messages*</samp> buffer.&nbsp;</dd>
-	<dt><code>(log-debug <var>string</var>)</code></dt>
-	<dd>Logs string to the file <code>debug.out</code>.</dd>
-	<dt><code>(get-version-string)</code></dt>
-	<dd>Returns the complete version string of Femto, including the copyright.</dd>
-	<dt>
-	<h3>Implementation Details</h3>
-
-	<p><mark>Tbd.: Memory consumption, limits, hacking, ...</mark></p>
-	</dt>
-</dl>
-</body>
+  <head>
+    <title>fLisp Manual</title>
+    <meta content="text/html; charset=utf-8" http-equiv="content-type" />
+    <meta content="Emacs, editor, Lisp, tiny, reference, manual" name="keywords" />
+    <meta content="Reference and user manual for the fLisp programming language and interpreter" name="description" />
+    <meta content="Georg Lehner &lt;jorge@magma-soft.at&gt;" name="author" />
+    <meta content="2023" name="copyright" />
+  </head>
+  <body>
+    <h1>fLisp Manual</h1>
+
+    <h3>Introduction</h3>
+    <blockquote>
+      <p>
+	A designer knows he has achieved perfection not when there is nothing left to add, but when there is nothing
+	left to take away.
+      </p>
+
+      <p>&mdash; Antoine de Saint-Exupery</p>
+    </blockquote>
+    <p>
+      <i>fLisp</i> is a tiny yet practical interpreter for a dialect of the Lisp programming language. It is used as
+      extension language for the <a href="https://github.com/matp/tiny-lisp">Femto</a> text editor.
+    </p>
+    <p>
+      <i>fLisp</i> originates from <a href="https://github.com/matp/tiny-lisp">Tiny-Lisp by matp </a>(pre 2014), was
+    integrated into <a href="https://github.com/hughbarney/femto">Femto</a> by Hugh Barnes (pre 2016) and compacted by
+    Georg Lehner in 2023.
+    </p>
+    <p>This is a reference manual. If you want to learn about Lisp programming use other resources eg.</p>
+    <ul>
+      <li>The <a href="lisp-lang.org">Common Lisp</a> web site,</li>
+      <li>
+	<a href="https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html">An Introduction to Programming in
+	  Emacs Lisp</a> or
+      </li>
+      <li><a href="https://www.scheme.org/">The Scheme Programming Language</a>.</li>
+    </ul>
+    <h3>Lisp</h3>
+    <h4>Notation Convention</h4>
+
+    <p>
+      <i>fLisp</i> fancies to converge toward Emacs Lisp. Function descriptions are annoted with a compatibility
+      scale:
+    </p>
+    <dl>
+      <dt><u>C</u></dt>
+      <dd>Interface compatible, though probably less featureful.</dd>
+      <dt><u>D</u></dt>
+      <dd>Same name, but different behavior.</dd>
+      <dt><u>S: <var>name</var></u></dt>
+      <dd><var>name</var> is a similar but not compatible function in Emacs Lisp.</dd>
+      <dt><u>B</u></dt>
+      <dd>Buggy/incompatible implementation.</dd>
+    </dl>
+    <p>Annotation is omitted if the function does not exist in Emacs Lisp.</p>
+
+    <p>We use the following notation rule for the <i>fLisp</i> syntax:</p>
+    <dl>
+      <dt><code><var>name</var></code></dt>
+      <dd>
+	<var>name</var> is the name of a variable. In Markdown documents it is shown with guillements, like
+	this <code>«name»</code>.</dd>
+      <dt><code>[text]</code></dt>
+      <dd><code>text</code> can be given zero or one time.</dd>
+      <dt><code>[text..]</code></dt>
+      <dd><code>text</code> can be given zero or more times.</dd>
+      <dt><q><code> </code></q></dt>
+      <dd>A single space is used to denote an arbitrary sequence of whitespace.</dd>
+    </dl>
+
+    <p>Notes:</p>
+    <ul>
+      <li>
+	<i>fLisp</i> does not use <code>[</code>square brackets<code>]</code> and double-dots <code>..</code> as
+	syntactical elements.
+      </li>
+      <li>String and number notation and formating conventions are the same as in the C language</li>
+    </ul>
+    
+    <h4>fLisp Interpreter</h4>
+
+    <p>When <i>fLisp</i> is invoked it follows a three step process:</p>
+    <ol>
+      <li>Read: program text is read in and converted into an internal representation.</li>
+      <li>Evaluate: the internal representation is evaluated</li>
+      <li>Print: the result of the evaluation is returned to the invoker.</li>
+    </ol>
+    <p>
+      Core functions of the language operate on built-in objects only. <i>fLisp</i> is extended with additional
+      functions in order to interact with editor related objects. With respect to the interpreter, extension functions
+      behave the same as core functions.
+    </p>
+
+    <h4>Syntax</h4>
+
+    <p>
+      Program text is written as a sequence of symbolic expressions - <abbr><dfn>sexp</dfn></abbr>&#39;s - in
+      parenthesized form. A sexp is either a single object or a function invocation enclosed in parens. Function
+      invocations can be infinitely nested.
+    </p>
+    <p>The following characters are special to the reader:</p>
+    <dl>
+      <dt><code>(</code></dt>
+      <dd>Starts a function invocation, <i>list</i> or <i>cons</i> object (see <a href="#objects_and_data_types">Objects
+      and Data Types</a>).</dd>
+      <dt><code>)</code></dt>
+      <dd>Finishes a function invocation, <i>list</i> or <i>cons</i> object</dd>
+      <dt><code>&quot;</code></dt>
+      <dd>Encloses strings.</dd>
+      <dt><code>&#39;</code></dt>
+      <dd>With a single quote prefix before a <abbr>sexp</abbr>, the <abbr>sexp</abbr> is expanded
+      to <code>(quote <var>sexp</var>)</code> before it is evaluated.</dd>
+      <dt><code>.</code></dt>
+      <dd>The expresion<code> (<var>a</var> . <var>b</var>)</code> evaluates to a <i>cons</i> object, holding the
+      objects <var>a</var> and <var>b</var>.</dd>
+    </dl>
+    <p>Numbers are represented in decimal notation.</p>
+    <p>A list of objects has the form:</p>
+    <blockquote>
+      <code>([<var>element</var> ..])</code>
+    </blockquote>
+    <p>A function invocation has the form:</p>
+    <blockquote>
+      <code>(<var>name</var> [<var>param</var> ..])</code>
+    </blockquote>
+    <p>There are two predefined objects. Their symbols are:</p>
+    <dl>
+      <dt><code>nil</code></dt>
+      <dd>
+	represents: the empty list: <code>()</code>, the end of a list marker or the false value in logical operations.
+      </dd>
+      <dt><code>t</code></dt>
+      <dd><q>true</q>, a predefined, non-false value.</dd>
+    </dl>
+
+    <h4 id="objects_and_data_types">Objects and Data Types</h4>
+
+    <p><i>fLisp</i> objects have exactly one of the following data types:</p>
+    <dl>
+      <dt><dfn>number</dfn></dt>
+      <dd>
+	<a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format">double precision floating point
+	  number.</a>
+      </dd>
+      <dt><dfn>string</dfn></dt>
+      <dd>character array.</dd>
+      <dt><dfn>cons</dfn></dt>
+      <dd>object holding two pointers to objects.</dd>
+      <dt><dfn>symbol</dfn></dt>
+      <dd>string with restricted character set: <code>[A-Z][0-9][a-z]!#$%&amp;*+-./:&lt;=&gt;?@^_~</code></dd>
+      <dt><dfn>lambda</dfn></dt>
+      <dd>anonymous function with parameter evaluation</dd>
+      <dt><dfn>macro</dfn></dt>
+      <dd>anonymous function without parameter evaluation</dd>
+    </dl>
+    <p>
+      Objects are unmutable, functions either create new objects or return existing ones.
+    </p>
+    <p>Characters do not have their own type. A single character is represented by a <i>string</i> with length one.</p>
+
+    <h4>Environments, Functions, Evaluation</h4>
+
+    <p>
+      All operations of the interpreter take place in an environment. An <dfn>environment</dfn> is a collection of named
+      objects. The object names are of type symbol.  An object in an environment is said to
+      be <dfn>bound</dfn> to its name. Environments can have a parent.  Each <i>fLisp</i> interpreter starts with
+      a <dfn>root</dfn> environment without a parent.
+    </p>
+    <p>
+      lambda and macro objects are functions. They have a parameter list and a sexp as body. When functions are invoked
+      a new environment is created as child of the current environment.  Functions receive zero or more objects from the
+      caller.  These are bound one by one to the symbols in the parameter list in the new environment.
+    </p>
+    <p>lambdas return the result of evaluating the body in the new environment.</p>
+    <p>
+      macros first evaluate the body in the calling environment. The resulting sexp is evaluated in the new environment
+      and that result is returned.  macro bodies are typically crafted to return new sexp's in terms of the
+      parameters.</p>
+    <p>
+      When a sexp is evaluated and encounters a symbol it looks it up in the current environment, and
+      then recursively in the environments from which the lambda or macro was invoked.  The symbol
+      of the first found binding is then replaced by its object.
+    </p>
+    <p>
+      <i>fLisp</i> counts with a set of built-in functions called <dfn>primitives</dfn>. They are grouped in the manual
+      by the type of objects they operate on. The primitives are bound in the global environment to the names under
+      which they are described.
+    </p>
+
+    <h4>Primitives</h4>
+
+    <h5>Interpreter Operations</h5>
+
+    <dl>
+      <dt><code>(progn[ <var>expr</var>..])</code></dt>
+      <dd>
+	Each <var>expr</var> is evaluated, the value of the last is returned. If no <var>expr</var> is
+	given, <code>progn</code> returns <code>nil</code>.
+      </dd>
+      <dt><code>(cond[ <var>clause</var>..])</code></dt>
+      <dd>
+	Each <var>clause</var> is of the form <code>(<var>pred</var>[ <var>action</var>])</code>. <code>cond</code>
+	evaluates each <var>clause</var> in turn. If <var>pred</var> evaluates to <code>nil</code>, the
+	next <var>clause</var> is tested. If <var>pred</var> evaluates not to <code>nil</code> and if there is
+	no <var>action</var> the value of <var>pred</var> is returned, otherwise <code>(progn <var>action</var>)</code>
+	is returned and no more <var>clause</var>s are evaluated.
+      </dd>
+      <dt><code>(setq <var>symbol</var> <var>value</var>[ <var>symbol</var> <var>value</var>..])</code></dt>
+      <dd>
+	Create or update named objects: If <var>symbol</var> is the name of an existing named object in the current or a
+	parent environment the named object is set to <var>value</var>, if no symbol with this name exists, a new one is
+	created in the current environment. <code>setq</code> returns the last <var>value</var>.
+      </dd>
+      <dt><code>(lambda <var>params</var> <var>body</var>)</code></dt>
+      <dd>
+	Returns a <var>lambda</var> function which accepts 0 or more arguments, which are passed as list in the
+	parameter <var>params</var>.
+      </dd> 
+      <dt><code>(lambda ([<var>param</var> ..]) <var>body</var>)</code></dt>
+      <dd>
+	Returns a <var>lambda</var> function which accepts the exact number of arguments given in the list
+	of <var>param</var>s.
+      </dd>
+      <dt><code>(lambda (<var>param</var>[ <var>param</var>..] . <var>opt</var>) <var>body</var>)</code></dt>
+      <dd>
+	Returns a <var>lambda</var> function which requires at least the exact number of arguments given in the list
+	of <var>param</var>s. All extra arguments are passed as a list in the parameter <var>opt</var>.
+      </dd>
+      <dt><code>(macro <var>params</var> <var>body</var>)</code></dt>
+      <dt><code>(macro ([<var>param</var> ..]) <var>body</var>)</code></dt>
+      <dt><code>(macro (<var>param</var>[ <var>param</var><..] . <var>opt</var>) <var>body</var>)</code></dt>
+      <dd>
+	These forms return a macro function. Parameter handling is the same as with lambda.
+      </dd>
+      <dt><code>(quote <var>expr</var>)</code></dt>
+      <dd>Returns <var>expr</var> without evaluating it.
+      </dd>
+      <dt><code>(signal <var>symbol</var> <var>list</var>)</code></dt>
+      <dd>tbd</dd>
+      <dt><code>(trap <var>list</var>)</code></dt>
+      <dd>tbd</dd>
+    </dl>
+
+    <h5>Object Operations</h5>
+
+    <dl>
+      <dt><code>(null <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is <code>nil</code>, otherwise <code>nil</code>.</dd>
+      <dt><code>(symbolp <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is of type symbol, otherwise <code>nil</code>.</dd>
+      <dt><code>(symbol-name <var>object</var>)</code></dt>
+      <dd>If <var>object</var> is of type symbol return its value as string.</dd>
+      <dt><code>(numberp <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is of type number, otherwise <code>nil</code>.</dd>
+      <dt><code>(stringp <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is of type string, otherwise <code>nil</code>.</dd>
+      <dt><code>(consp <var>object</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>object</var> is of type cons, otherwise <code>nil</code>.</dd>
+      <dt><code>(cons <var>car</var> <var>cdr</var>)</code></dt>
+      <dd>Returns a new cons with the first object set to the value of <var>car</var> and the second to the value of <var>cdr</var>.</dd>
+      <dt><code>(car <var>cons</var>)</code></dt>
+      <dd>Returns the first object of <var>cons</var>.</dd>
+      <dt><code>(cdr <var>cons</var>)</code></dt>
+      <dd>Returns the second object of <var>cons</var>.</dd>
+      <dt><code>(eq <var>a</var> <var>b</var>)</code></dt>
+      <dd>Returns <code>t</code> if <var>a</var> and <var>b</var> evaluate to the same object, <code>nil</code> otherwise.</dd>
+      <dt><code>(print <var>object</var>)</code></dt>
+      <dd>
+	Formats <var>object</var> into a string which can be read by the reader and returns it. As a side effect, the
+	string is printed to the output stream with a leading and a closing newline. <code>print</code> escapes quotes
+	in strings with a backslash.
+      </dd>
+      <dt><code>(princ <var>object</var>)</code></dt>
+      <dd>
+	Formats <var>object</var> into a string and returns it, As a side effect, the string is printed to the output
+	stream.
+      </dd>
+    </dl>
+
+    <h5>String Operations</h5>
+
+    <dl>
+      <dt><code>(string.length <var>string</var>)</code></dt>
+      <dd>Returns the length of <var>string</var> as a <i>number</i>.</dd>
+      <dt><code>(string.substring <var>string</var> <var>start</var> <var>end</var>)</code></dt>
+      <dd>
+	Returns the substring from <var>string</var> which starts with the character at index <var>start</var> and ends
+	with index <var>end</var>. String indexes are zero based.
+      </dd>
+      <dt><code>(string.append <var>string1</var> <var>string2</var>)</code></dt>
+      <dd>Returns a new string consisting of the concatenation of <var>string1</var> with <var>string2</var>.</dd>
+      <dt><code>(string-to-number <var>string</var>)</code></dt>
+      <dd>
+	Converts <var>string</var> into a corresponding <i>number</i> object. String is interpreted as decimal based
+	integer.
+      </dd>
+      <dt><code>(number-to-string <var>number</var>)</code></dt>
+      <dd>Converts <var>number</var> into a <i>string</i> object.
+      </dd>
+      <dt><code>(ascii <var>number</var>)</code></dt>
+      <dd>
+	Converts <var>number</var> into a <i>string</i> with one character, which corresponds to the ASCII
+	representation of <var>number</var>.
+      </dd>
+      <dt><code>(ascii-&gt;number <var>string</var>)</code></dt>
+      <dd>
+	Converts the first character of <var>string</var> into a <i>number</i> which corresponds to its ASCII
+	value.
+      </dd>
+    </dl>
+
+    <h5>Arithmetic Operations</h5>
+
+    <dl>
+      <dt><code>(+[ <var>arg</var>..])</code></dt>
+      <dd>Returns the sum of all <var>arg</var>s or <code>0</code> if none is given.</dd>
+      <dt><code>(*[ <var>arg</var>..])</code></dt>
+      <dd>Returns the product of all <var>arg</var>s or <code>1</code> if none given.</dd>
+      <dt><code>(-[ <var>arg</var>..])</code></dt>
+      <dd>
+	Returns 0 if no <var>arg</var> is given, -<var>arg</var> if only one is given, <var>arg</var> minus the sum of
+	all others otherwise.
+      </dd>
+      <dt><code>(/ <var>arg</var>[ <var>div</var>..])</code></dt>
+      <dd>
+	Returns 1/<var>arg</var> if no <var>div</var> is given, <var>arg</var>/<var>div</var>[/<var>div</var>..] if one
+	or more <var>div</var>s are given, <code>inf</code> if one of the <var>div</var>s is <code>0</code> and the sum
+	of the signs of all operands is even, <code>-inf</code> if it is odd.
+      </dd>
+      <dt><code>(% <var>arg</var>[ <var>div</var>..])</code></dt>
+      <dd>
+	Returns <code>1</code> if no <var>div</var> is given, <var>arg</var>%<var>div</var>[%<var>div</var>..] if one
+	or more <var>div</var>s are given. If one of the divs is <code>0</code>, the program exits with an arithmetic
+	exception.
+      </dd>
+      <dt><code>(= <var>arg</var>[ <var>arg</var>..])</code></dt>
+      <dt><code>(&lt; <var>arg</var>[ <var>arg</var>..])</code></dt>
+      <dt><code>(&gt; <var>arg</var>[ <var>arg</var>..])</code></dt>
+      <dt><code>(&lt;= <var>arg</var>[ <var>arg</var>..])</code></dt>
+      <dt><code>(&gt;= <var>arg</var>[ <var>arg</var>..])</code></dt>
+      <dd>
+	These predicate functions apply the respective comparison operator between all <var>arg</var>s and return the
+	respective result as <code>t</code> or <code>nil</code>.  If only one <var>arg</var> is given they all
+	return <code>t</code>.
+      </dd>
+    </dl>
+
+    <h3>Editor Extension</h3>
+
+    <p>The editor extensions introduces several types of objects/functionality:</p>
+    <ul>
+      <li><dfn>Buffers</dfn> hold text</li>
+      <li><dfn>Windows</dfn> display buffer contents to the user</li>
+      <li><dfn>Keyboard Input</dfn> allows the user to interact with buffers and windows</li>
+      <li>The <dfn>Message Line</dfn> gives feedback to the user</li>
+      <li>Several other function for operating system or user interaction</li>
+    </ul>
+
+    <h4>Buffers</h4>
+
+    <p>
+      This section describes the buffer related functions added by Femto to fLisp. The description is separated in
+      function related to buffer management and text manipulation.  Text manipulation always operates on
+      the <dfn>current buffer</dfn>. Buffer management creates, deletes buffers, or selects one of the existing buffers
+      as the current buffer.  current buffercode.
+    </p>
+
+    <p>Buffers store text and allow to manipulate it. A buffer has the following properties:</p>
+    <dl>
+      <dt><var>name</var></dt>
+      <dd>
+	Buffers are identified by their name. If a buffer name is enclosed in <samp>*</samp>asterisks<samp>*</samp> the
+	buffer receives special treatment.
+      </dd>
+      <dt><var>text</var></dt>
+      <dd>0 or more characters.</dd>
+      <dt><var>point</var></dt>
+      <dd>The position in the text where text manipulation takes place.</dd>
+      <dt><var>mark</var></dt>
+      <dd>
+	An optional second position in the text. If the <var>mark</var> is set, the text between <var>point</var>
+	and <var>mark</var> is called the <dfn>selection</dfn> or <dfn>region</dfn>.
+      </dd>
+      <dt><var>filename</var></dt>
+      <dd>If set the buffer is associated with the respective file.</dd>
+      <dt><var>flags</var></dt>
+      <dd>Different flags determine the behaviour of the buffer.</dd>
+    </dl>
+
+    <p>In the following, all mentions of these variables refer to the current buffers properties.</p>
+    
+    <h5>Text manipulation</h5>
+
+    <dl>
+      <dt><code>(insert-string <var>string</var>)</code></dt>
+      <dd>Inserts <var>string</var> at <var>point</var>. <u>S: insert</u>.</dd>
+      <dt><code>(insert-file-contents-literally <var>string</var> </code>[<code><var>flag</var></code>]<code>)</code></dt>
+      <dd>
+	Inserts the file <var>string</var> after <var>point</var>. If <var>flag</var> is not nil the buffer is marked as not
+	modified. <u>B</u>
+      </dd>
+      <dd>
+	<p>
+	  Note: Currently the flag is forced to nil. The function should
+	  return <code>(<var>filename</var> <var>count</var>)</code> but it returns a flag indicating if the operation
+	  succeeded.
+	</p>
+      </dd>
+      <dt><code>(erase-buffer)</code></dt>
+      <dd>Erases all text in the current buffer. <u>C</u></dd>
+      <dt><code>(delete)</code></dt>
+      <dd>Deletes the character after <var>point</var>. <u>S: delete-char</u></dd>
+      <dt><code>(backspace)</code></dt>
+      <dd>Deletes the character to the left of <var>point</var>. <u>S: delete-backward-char</u></dd>
+      <dt><code>(get-char)</code></dt>
+      <dd>Returns the character to the left of <var>point</var>. <u>S: get-byte</u></dd>
+      <dt><code>(copy-region)</code></dt>
+      <dd>Copies <var>region</var> to the <var>clipboard</var>. <u>S: copy-region-as-kill</u></dd>
+      <dt><code>(kill-region)</code></dt>
+      <dd>Deletes the text in the <var>region</var> and copies it to the <var>clipboard</var>. <u>D</u></dd>
+      <dt><code>(yank)</code></dt>
+      <dd>Pastes the <var>clipboard</var> before <var>point</var>. <u>C</u></dd>
+    </dl>
+
+    <h5>Selection</h5>
+
+    <dl>
+      <dt><code>(set-mark)</code></dt>
+      <dd>Sets <var>mark</var> to <var>point</var>. <u>D</u></dd>
+      <dt><code>(get-mark)</code></dt>
+      <dd>Returns the position of <var>mark</var>, -1 if <var>mark</var> is unset. <u>S: mark</u></dd>
+      <dt><code>(get-point)</code></dt>
+      <dd>Returns the position of <var>point</var>. <u>S: point</u></dd>
+      <dt><code>(get-point-max)</code></dt>
+      <dd>Returns the maximum accessible value of point in the current buffer. <u>S: point-max</u></dd>
+      <dt><code>(set-clipboard <var>variable</var>)</code></dt>
+      <dd><code>Sets <var>clipboard</var> to the contents of <var>variable</var>.</code> <u>S: gui-set-selection</u></dd>
+      <dt><code>(get-clipboard)</code></dt>
+      <dd>Returns the <var>clipboard</var> contents.  <u>S: gui-get-selection</u></dd>
+    </dl>
+
+    <h5>Cursor Movement</h5>
+
+    <dl>
+      <dt><code>(set-point <var>number</var>)</code></dt>
+      <dd>Sets the point to in the current buffer to the position <var>number</var>. <u>S: goto-char</u></dd>
+      <dt><code>(goto-line <var>number</var>)</code></dt>
+      <dd>
+	Sets the point in the current buffer to the first character on line <var>number</var>. <u>S: goto-line</u>, not
+	an Elisp function.
+      </dd>
+      <dt><code>(search-forward <var>string</var>)</code></dt>
+      <dd>
+	Searches for <var>string</var> in the current buffer, starting from point forward. If string is found, sets the
+	point after the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point alone
+	and returns <samp>nil</samp>. <u>D</u>
+      </dd>
+      <dt><code>(search-backward <var>string</var>)</code></dt>
+      <dd>
+	Searches for <var>string</var> in the current buffer, starting from point backwards. If string is found, sets
+	the point before the first occurrence of <var>string</var> and returns <samp>t</samp>, otherwise leaves point
+	alone and returns <samp>nil</samp>. <u>D</u>
+      </dd>
+      <dt><code>(beginning-of-buffer)</code></dt>
+      <dd>
+	Sets the point in the current buffer to the first buffer position, leaving mark in its current
+	position. <u>C</u>
+      </dd>
+      <dt><code>(end-of-buffer)</code></dt>
+      <dd>
+	Sets the point in the current buffer to the last buffer position, leaving mark in its current position. <u>C</u>
+      </dd>
+      <dt><code>(beginning-of-line)</code></dt>
+      <dd>
+	Sets point before the first character of the current line, leaving mark in its current position. <u>S:
+	  move-beginning-of-line</u>
+      </dd>
+      <dt><code>(end-of-line)</code></dt>
+      <dd>
+	Sets point after the last character of the current line, i.e. before the end-of-line character sequence, leaving
+	mark in its current position. <u>S: move-end-of-line</u>
+      </dd>
+      <dt><code>(forward-word)</code></dt>
+      <dd>
+	Moves the point in the current buffer forward before the first char of the next word. If there is no word left
+	the point is set to the end of the buffer. If the point is already at the start or within a word, the current
+	word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>end</em> of the the next word.
+      </dd>
+      <dt><code>(backward-word)</code></dt>
+      <dd>
+	Moves the point in the current buffer backward after the last char of the previous word. If there is no word
+	left the point is set to the beginning of the buffer. If the point is already at the end or within a word, the
+	current word is skipped. <u>D</u>: <b>Note</b>: Elisp moves to the <em>beginning</em> of the previous word.
+      </dd>
+      <dt><code>(forward-char)</code></dt>
+      <dd>Moves the point in the current buffer one character forward, but not past the end of the buffer. <u>C</u></dd>
+      <dt><code>(backward-char)</code></dt>
+      <dd>
+	Moves the point in the current buffer one character backward, but not before the end of the
+	buffer. <u>C</u>
+      </dd> 
+      <dt><code>(forward-page)</code></dt>
+      <dd>
+	Moves the point of the current buffer to the beginning of the last visible line of the associated screen and
+	scrolls the screen up to show it as the first line. <u>S: scroll-up</u>
+      </dd>
+      <dt><code>(backward-page)</code></dt>
+      <dd>
+	Moves the point of the current buffer to the beginning of the first visible line of the associoated screen and
+	scrolls the screen down to show it as the last line. <u>S: scroll-down</u>
+      </dd>
+      <dt><code>(next-line)</code></dt>
+      <dd>
+	Moves the point in the current buffer to the same character position in the next line, or to the end of the next
+	line if there are not enough characters. In the last line of the buffer moves the point to the end of the
+	buffer. <u>C</u>
+      </dd>
+      <dt><code>(previous-line)</code></dt>
+      <dd>
+	Moves the point in the current buffer to the same character position in the previous line, or to the end of the
+	previous line if there are not enough characters. In the first line of the buffer the point is not
+	moved. <u>C</u>
+      </dd>
+    </dl>
+
+    <h5>Buffer management</h5>
+
+    <dl>
+      <dt><code>(list-buffers)</code></dt>
+      <dd>Lists all the buffers in a buffer called <samp>*buffers*</samp>.</dd>
+      <dt><code>(get-buffer-count)</code></dt>
+      <dd>Returns the number of buffers, includes all special buffers and <samp>*buffers*</samp>.</dd>
+      <dt><code>(select-buffer <var>string</var>)</code></dt>
+      <dd>Makes the buffer named <var>string</var> the current buffer. Note: <u>C</u> to <code>set-buffer</code> in Elisp.</dd>
+      <dt><code>(rename-buffer <var>string</var>)</code></dt>
+      <dd>Rename the current buffer to <var>string</var>. <u>C</u></dd>
+      <dt><code>(kill-buffer <var>string</var>)</code></dt>
+      <dd>Kill the buffer names <var>string</var>. Unsaved changes are discarded. <u>C</u></dd>
+      <dt><code>(get-buffer-name)</code></dt>
+      <dd>Return the name of the current buffer. Note: <u>C</u> to <code>buffer-name</code> in Elisp.</dd>
+      <dt><code>(add-mode-global <var>string</var>)</code></dt>
+      <dd>Sets global mode <var>string</var> for all buffers. Currently the only global mode is <kbd>undo</kbd>.</dd>
+      <dt><code>(find-file <var>string</var>)</code></dt>
+      <dd>Loads file with path string into a new buffer. <u>C</u></dd>
+      <dt><code>(save-buffer <var>string</var>)</code></dt>
+      <dd>Saves the buffer named <var>string</var> to disk. <u>C</u></dd>
+    </dl>
+
+    <h4>User Interaction</h4>
+
+    <p>
+      This section lists function related to window and message line manipulation, keyboard input and system
+      interaction.
+    </p>
+
+    <h5>Window Handling</h5>
+
+    <dl>
+      <dt><code>(delete-other-windows)</code></dt>
+      <dd>Make current window the only window. <u>C</u></dd>
+      <dt><code>(split-window)</code></dt>
+      <dd>Splits the current window. Creates a new window for the current buffer. <u>C</u></dd>
+      <dt><code>(other-window)</code></dt>
+      <dd>
+	Moves the cursor to the next window down on the screen. Makes the buffer in that window the current
+	buffer. <u>D</u>
+      </dd> 
+      <dd>
+	<p>Note: Elisp <code>other-window</code> has a required parameter <var>count</var>, which specifies the number
+	  of windows to move down or up.
+	</p>
+      </dd>
+      <dt><code>(update-display)</code></dt>
+      <dd>Updates all modified windows.</dd>
+      <dt><code>(refresh)</code></dt>
+      <dd>Updates all windows by marking them modified and calling <code>update-display</code>.</dd>
+    </dl>
+
+    <h5>Message Line</h5>
+    <dl>
+      <dt><code>(message <var>string</var>)</code></dt>
+      <dd>Displays <var>string</var> in the message line. <u>D</u></dd>
+      <dt><code>(clear-message-line)</code></dt>
+      <dd>Displays the empty string in the message line.</dd>
+      <dt><code>(prompt <var>prompt</var> <var>default</var>)</code></dt>
+      <dd>
+	Displays <var>prompt</var> in the command line and sets <var>default</var> as initial value for the user
+	respones. The user can edit the response. When hitting return, the final response is returned.
+      </dd>
+      <dt><code>(show-prompt <var>prompt</var> <var>default</var>)</code></dt>
+      <dd>
+	Displays <var>prompt</var> and <var>default</var> in the commandline, but does not allow
+	editing. Returns <code>t</code>.
+      </dd>
+      <dt><code>(prompt-filename <var>prompt</var>)</code></dt>
+      <dd>
+	Displays <var>prompt</var> in the commandline and allows to enter or search for a file name. Returns the
+	relative path to the selected file name or the response typed by the user.
+      </dd>
+    </dl>
+
+    <h5>Keyboard Handling</h5>
+
+    <dl>
+      <dt><code>(set-key <var>key-name</var> <var>lisp-func</var>)</code></dt>
+      <dd>Binds key key-name to the lisp function <var>lisp-func</var>.</dd>
+      <dt><code>(get-key-name)</code></dt>
+      <dd>Returns the name of the currently pressed key, eg: <samp>c-k</samp> for control-k.</dd>
+      <dt><code>(get-key-funcname)</code></dt>
+      <dd>Return the name of the function bound to the currently pressed key.</dd>
+      <dt><code>(execute-key)</code></dt>
+      <dd>Executes the function of the last bound key. <mark>Tbd. bound or pressed?</mark></dd>
+      <dt><code>(describe-bindings)</code></dt>
+      <dd>
+	Creates a listing of all current key bindings, in a buffer named <samp>*help*</samp> and displays it in a new
+	window. <u>C</u>
+      </dd>
+      <dt><code>(describe-functions)</code></dt>
+      <dd>
+	Creates a listing of all functions bound to keys in a buffer named <samp>*help*</samp> and displays it in a new
+	window.
+      </dd>
+      <dt><code>(getch)</code></dt>
+      <dd>
+	Waits for a key to be pressed and returns the key as string. See
+	also <code>get-key-name</code>, <code>get-key-funcname</code> and <code>execute-key</code>.
+      </dd>
+    </dl>
+
+    <h5>Programming and System Interaction</h5>
+
+    <dl>
+      <dt><code>(exit)</code></dt>
+      <dd>Exit Femto without saving modified buffers.</dd>
+      <dt><code>(eval-block)</code></dt>
+      <dd>
+	Evaluates the <var>region</var> in the current buffer, inserts the result at <var>point</var> and returns
+	it. If <var>mark</var> in the current buffer is before <var>point</var> <code>eval-block</code> evaluates
+	this <var>region</var> and inserts the result at <var>point</var>. If <var>point</var> is
+	before <var>mark</var> <code>eval-block</code> does nothing but returning <samp>t</samp>.
+      </dd>
+      <dt><code>(system <var>string</var>)</code></dt>
+      <dd>
+	Executes the <a href="https://man7.org/linux/man-pages/man3/system.3.html">system(1)</a> function
+	with <var>string</var> as parameter.
+      </dd>
+      <dt><code>(os.getenv <var>string</var>) </code></dt>
+      <dd>Returns the value of the environment variable named <var>string</var>.</dd>
+      <dt><code>(log-message <var>string</var>)</code></dt>
+      <dd>Logs <var>string</var> to the <samp>*messages*</samp> buffer. </dd>
+      <dt><code>(log-debug <var>string</var>)</code></dt>
+      <dd>Logs string to the file <code>debug.out</code>.</dd>
+      <dt><code>(get-version-string)</code></dt>
+      <dd>Returns the complete version string of Femto, including the copyright.</dd>
+    </dl>
+    
+    <h3>Implementation Details</h3>
+
+    <p><mark>Tbd.: Memory consumption, limits, hacking, ...</mark></p>
+  </body>
 </html>
+<!--
+    Emacs:
+    Local Variables:
+    fill-column: 120
+    End:
+  -->

--- a/pdoc/flisp.html
+++ b/pdoc/flisp.html
@@ -249,10 +249,10 @@
       </dd>
       <dt><code>(cond[ <var>clause</var>..])</code></dt>
       <dd>
-	Each <var>clause</var> is of the form <code>(<var>pred</var>[ <var>action</var>])</code>. <code>cond</code>
+	Each <var>clause</var> is of the form <code>(<var>pred</var>[ <var>action</var> ..])</code>. <code>cond</code>
 	evaluates each <var>clause</var> in turn. If <var>pred</var> evaluates to <code>nil</code>, the
 	next <var>clause</var> is tested. If <var>pred</var> evaluates not to <code>nil</code> and if there is
-	no <var>action</var> the value of <var>pred</var> is returned, otherwise <code>(progn <var>action</var>)</code>
+	no <var>action</var> the value of <var>pred</var> is returned, otherwise <code>(progn <var>action</var> ..)</code>
 	is returned and no more <var>clause</var>s are evaluated.
       </dd>
       <dt><code>(setq <var>symbol</var> <var>value</var>[ <var>symbol</var> <var>value</var>..])</code></dt>
@@ -423,9 +423,12 @@
 	buffer receives special treatment.
       </dd>
       <dt><var>text</var></dt>
-      <dd>0 or more characters.</dd>
+      <dd>zero or more characters.</dd>
       <dt><var>point</var></dt>
-      <dd>The position in the text where text manipulation takes place.</dd>
+      <dd>
+	The position in the text where text manipulation takes place. The first position in the text is 0. Note:
+	in Emacs the first position is 1.
+      </dd>
       <dt><var>mark</var></dt>
       <dd>
 	An optional second position in the text. If the <var>mark</var> is set, the text between <var>point</var>
@@ -443,7 +446,7 @@
 
     <dl>
       <dt><code>(insert-string <var>string</var>)</code></dt>
-      <dd>Inserts <var>string</var> at <var>point</var>. <u>S: insert</u>.</dd>
+      <dd>Inserts <var>string</var> before <var>point</var>. <u>S: insert</u>.</dd>
       <dt><code>(insert-file-contents-literally <var>string</var> </code>[<code><var>flag</var></code>]<code>)</code></dt>
       <dd>
 	Inserts the file <var>string</var> after <var>point</var>. If <var>flag</var> is not nil the buffer is marked as not
@@ -463,7 +466,7 @@
       <dt><code>(backspace)</code></dt>
       <dd>Deletes the character to the left of <var>point</var>. <u>S: delete-backward-char</u></dd>
       <dt><code>(get-char)</code></dt>
-      <dd>Returns the character to the left of <var>point</var>. <u>S: get-byte</u></dd>
+      <dd>Returns the character at <var>point</var>. <u>S: get-byte</u></dd>
       <dt><code>(copy-region)</code></dt>
       <dd>Copies <var>region</var> to the <var>clipboard</var>. <u>S: copy-region-as-kill</u></dd>
       <dt><code>(kill-region)</code></dt>

--- a/pdoc/flisp.html
+++ b/pdoc/flisp.html
@@ -69,7 +69,7 @@
     </blockquote>
     <p>
       <i>fLisp</i> is a tiny yet practical interpreter for a dialect of the Lisp programming language. It is used as
-      extension language for the <a href="https://github.com/matp/tiny-lisp">Femto</a> text editor.
+      extension language for the <a href="https://github.com/hughbarney/femto">Femto</a> text editor.
     </p>
     <p>
       <i>fLisp</i> originates from <a href="https://github.com/matp/tiny-lisp">Tiny-Lisp by matp </a>(pre 2014), was
@@ -78,7 +78,7 @@
     </p>
     <p>This is a reference manual. If you want to learn about Lisp programming use other resources eg.</p>
     <ul>
-      <li>The <a href="lisp-lang.org">Common Lisp</a> web site,</li>
+      <li>The <a href="https://lisp-lang.org">Common Lisp</a> web site,</li>
       <li>
 	<a href="https://www.gnu.org/software/emacs/manual/html_node/eintr/index.html">An Introduction to Programming in
 	  Emacs Lisp</a> or

--- a/pdoc/flisp.html
+++ b/pdoc/flisp.html
@@ -11,7 +11,54 @@
   <body>
     <h1>fLisp Manual</h1>
 
-    <h3>Introduction</h3>
+    <aside>
+      <p>Table of Contents</p>
+      <ol>
+	<li><a href="#introduction">Introduction</a></li>
+	<li><a href="#lisp">Lisp</a></li>
+	<ol>
+	  <li><a href="#notation">Notation Convention</a></li>
+	  <li><a href="#interpreter">fLisp Interpreter</a></li>
+	  <li><a href="#syntax">Syntax</a></li>
+	  <li><a href="#objects_and_data_types">Objects and Data Types</a></li>
+	  <li><a href="#evaluation">Environments, Functions, Evaluation</a></li>
+	  <li><a href="#primitives">Primitives</a></li>
+	  <ol>
+	    <li><a href="#interp_ops">Interpreter Operations</a></li>
+	    <li><a href="#object_ops">Object Operations</a></li>
+	    <li><a href="#string_ops">String Operations</a></li>
+	    <li><a href="#arithmetic_ops">Arithmetic Operations</a></li>
+	  </ol>
+	</ol>
+	<li><a href="#editor">Editor Extension</li>
+	<ol>
+	  <li><a href="#buffers">Buffers</a></li>
+	  <ol>
+	    <li><a href="#text">Text manipulation</a></li>
+	    <li><a href="#selection">Selection</a></li>
+	    <li><a href="#cursor">Cursor Movement</a></li>
+	    <li><a href="#buffer_management">Buffer management</a></li>
+	  </ol>
+	  <li><a href="#ui">User Interaction</a></li>
+	  <ol>
+	    <li><a href="#windows">Window Handling"</a></li>
+	    <li><a href="#message_line">Message Line</a></li>
+	    <li><a href="#keyboard">Keyboard Handling</a></li>
+	    <li><a href="#programming_system">Programming and System Interaction</a></li>
+	  </ol>
+	</ol>
+	<li><a href="#exceptions">Error Handling</a></li>
+	<li><a href="#embedding">Embedding fLisp</a></li>
+	<li><a href="#implementation">Implementation Details</a></li>
+	<ol>
+	  <li><a href="#gc">Garbage Collection</a></li>
+	  <li><a href="#memory">Memory Usage</a></li>
+	  <li><a href="#future">Future Directions</a></li>
+	</ol>
+      </ol>
+    </aside>
+
+    <h3 id="introduction">Introduction</h3>
     <blockquote>
       <p>
 	A designer knows he has achieved perfection not when there is nothing left to add, but when there is nothing
@@ -38,11 +85,11 @@
       </li>
       <li><a href="https://www.scheme.org/">The Scheme Programming Language</a>.</li>
     </ul>
-    <h3>Lisp</h3>
-    <h4>Notation Convention</h4>
+    <h3 id="lisp">Lisp</h3>
+    <h4 id="notation">Notation Convention</h4>
 
     <p>
-      <i>fLisp</i> fancies to converge toward Emacs Lisp. Function descriptions are annoted with a compatibility
+      <i>fLisp</i> fancies to converge toward Emacs Lisp. Function descriptions are annotated with a compatibility
       scale:
     </p>
     <dl>
@@ -61,7 +108,7 @@
     <dl>
       <dt><code><var>name</var></code></dt>
       <dd>
-	<var>name</var> is the name of a variable. In Markdown documents it is shown with guillements, like
+	<var>name</var> is the name of a variable. In Markdown documents it is shown with guillemots, like
 	this <code>«name»</code>.</dd>
       <dt><code>[text]</code></dt>
       <dd><code>text</code> can be given zero or one time.</dd>
@@ -77,10 +124,10 @@
 	<i>fLisp</i> does not use <code>[</code>square brackets<code>]</code> and double-dots <code>..</code> as
 	syntactical elements.
       </li>
-      <li>String and number notation and formating conventions are the same as in the C language</li>
+      <li>String and number notation and formatting conventions are the same as in the C language</li>
     </ul>
     
-    <h4>fLisp Interpreter</h4>
+    <h4 id="interpreter">fLisp Interpreter</h4>
 
     <p>When <i>fLisp</i> is invoked it follows a three step process:</p>
     <ol>
@@ -94,7 +141,7 @@
       behave the same as core functions.
     </p>
 
-    <h4>Syntax</h4>
+    <h4 id="syntax">Syntax</h4>
 
     <p>
       Program text is written as a sequence of symbolic expressions - <abbr><dfn>sexp</dfn></abbr>&#39;s - in
@@ -114,7 +161,7 @@
       <dd>With a single quote prefix before a <abbr>sexp</abbr>, the <abbr>sexp</abbr> is expanded
       to <code>(quote <var>sexp</var>)</code> before it is evaluated.</dd>
       <dt><code>.</code></dt>
-      <dd>The expresion<code> (<var>a</var> . <var>b</var>)</code> evaluates to a <i>cons</i> object, holding the
+      <dd>The expression<code> (<var>a</var> . <var>b</var>)</code> evaluates to a <i>cons</i> object, holding the
       objects <var>a</var> and <var>b</var>.</dd>
     </dl>
     <p>Numbers are represented in decimal notation.</p>
@@ -157,11 +204,11 @@
       <dd>anonymous function without parameter evaluation</dd>
     </dl>
     <p>
-      Objects are unmutable, functions either create new objects or return existing ones.
+      Objects are immutable, functions either create new objects or return existing ones.
     </p>
     <p>Characters do not have their own type. A single character is represented by a <i>string</i> with length one.</p>
 
-    <h4>Environments, Functions, Evaluation</h4>
+    <h4 id="evaluation">Environments, Functions, Evaluation</h4>
 
     <p>
       All operations of the interpreter take place in an environment. An <dfn>environment</dfn> is a collection of named
@@ -190,9 +237,9 @@
       which they are described.
     </p>
 
-    <h4>Primitives</h4>
+    <h4 id="primitives">Primitives</h4>
 
-    <h5>Interpreter Operations</h5>
+    <h5 id="interp_ops">Interpreter Operations</h5>
 
     <dl>
       <dt><code>(progn[ <var>expr</var>..])</code></dt>
@@ -238,13 +285,13 @@
       <dt><code>(quote <var>expr</var>)</code></dt>
       <dd>Returns <var>expr</var> without evaluating it.
       </dd>
-      <dt><code>(signal <var>symbol</var> <var>list</var>)</code></dt>
-      <dd>tbd</dd>
-      <dt><code>(trap <var>list</var>)</code></dt>
-      <dd>tbd</dd>
+      <dt><code>(signal <var>type</var> <var>list</var>)</code></dt>
+      <dd>Throws an exception, stopping any further evaluation.  Exceptions can be typed via the symbol <var>type</var>
+	and must contain a list of exception related objects.  <code>(signal 'error 'nil)</code> is probably the
+	simplest signal.</dd>
     </dl>
 
-    <h5>Object Operations</h5>
+    <h5 id="object_ops">Object Operations</h5>
 
     <dl>
       <dt><code>(null <var>object</var>)</code></dt>
@@ -280,14 +327,14 @@
       </dd>
     </dl>
 
-    <h5>String Operations</h5>
+    <h5 id="string_ops">String Operations</h5>
 
     <dl>
       <dt><code>(string.length <var>string</var>)</code></dt>
       <dd>Returns the length of <var>string</var> as a <i>number</i>.</dd>
       <dt><code>(string.substring <var>string</var> <var>start</var> <var>end</var>)</code></dt>
       <dd>
-	Returns the substring from <var>string</var> which starts with the character at index <var>start</var> and ends
+	Returns the sub string from <var>string</var> which starts with the character at index <var>start</var> and ends
 	with index <var>end</var>. String indexes are zero based.
       </dd>
       <dt><code>(string.append <var>string1</var> <var>string2</var>)</code></dt>
@@ -312,7 +359,7 @@
       </dd>
     </dl>
 
-    <h5>Arithmetic Operations</h5>
+    <h5 id="arithmetic_ops">Arithmetic Operations</h5>
 
     <dl>
       <dt><code>(+[ <var>arg</var>..])</code></dt>
@@ -332,9 +379,9 @@
       </dd>
       <dt><code>(% <var>arg</var>[ <var>div</var>..])</code></dt>
       <dd>
-	Returns <code>1</code> if no <var>div</var> is given, <var>arg</var>%<var>div</var>[%<var>div</var>..] if one
-	or more <var>div</var>s are given. If one of the divs is <code>0</code>, the program exits with an arithmetic
-	exception.
+	Returns <code>1</code> if no <var>div</var> is given, <var>arg</var>%<var>div</var>[%<var>div</var>..] if one or
+	more <var>div</var>s are given. If one of the <var>div</var>s is <code>0</code>, the program exits with an
+	arithmetic exception.
       </dd>
       <dt><code>(= <var>arg</var>[ <var>arg</var>..])</code></dt>
       <dt><code>(&lt; <var>arg</var>[ <var>arg</var>..])</code></dt>
@@ -348,7 +395,7 @@
       </dd>
     </dl>
 
-    <h3>Editor Extension</h3>
+    <h3 id="editor">Editor Extension</h3>
 
     <p>The editor extensions introduces several types of objects/functionality:</p>
     <ul>
@@ -359,13 +406,13 @@
       <li>Several other function for operating system or user interaction</li>
     </ul>
 
-    <h4>Buffers</h4>
+    <h4 id="buffers">Buffers</h4>
 
     <p>
       This section describes the buffer related functions added by Femto to fLisp. The description is separated in
       function related to buffer management and text manipulation.  Text manipulation always operates on
       the <dfn>current buffer</dfn>. Buffer management creates, deletes buffers, or selects one of the existing buffers
-      as the current buffer.  current buffercode.
+      as the current buffer.
     </p>
 
     <p>Buffers store text and allow to manipulate it. A buffer has the following properties:</p>
@@ -387,12 +434,12 @@
       <dt><var>filename</var></dt>
       <dd>If set the buffer is associated with the respective file.</dd>
       <dt><var>flags</var></dt>
-      <dd>Different flags determine the behaviour of the buffer.</dd>
+      <dd>Different flags determine the behavior of the buffer.</dd>
     </dl>
 
     <p>In the following, all mentions of these variables refer to the current buffers properties.</p>
     
-    <h5>Text manipulation</h5>
+    <h5 id="text">Text manipulation</h5>
 
     <dl>
       <dt><code>(insert-string <var>string</var>)</code></dt>
@@ -425,7 +472,7 @@
       <dd>Pastes the <var>clipboard</var> before <var>point</var>. <u>C</u></dd>
     </dl>
 
-    <h5>Selection</h5>
+    <h5 id="selection">Selection</h5>
 
     <dl>
       <dt><code>(set-mark)</code></dt>
@@ -442,7 +489,7 @@
       <dd>Returns the <var>clipboard</var> contents.  <u>S: gui-get-selection</u></dd>
     </dl>
 
-    <h5>Cursor Movement</h5>
+    <h5 id="cursor">Cursor Movement</h5>
 
     <dl>
       <dt><code>(set-point <var>number</var>)</code></dt>
@@ -509,7 +556,7 @@
       </dd>
       <dt><code>(backward-page)</code></dt>
       <dd>
-	Moves the point of the current buffer to the beginning of the first visible line of the associoated screen and
+	Moves the point of the current buffer to the beginning of the first visible line of the associated screen and
 	scrolls the screen down to show it as the last line. <u>S: scroll-down</u>
       </dd>
       <dt><code>(next-line)</code></dt>
@@ -526,7 +573,7 @@
       </dd>
     </dl>
 
-    <h5>Buffer management</h5>
+    <h5 id="buffer_management">Buffer management</h5>
 
     <dl>
       <dt><code>(list-buffers)</code></dt>
@@ -549,14 +596,14 @@
       <dd>Saves the buffer named <var>string</var> to disk. <u>C</u></dd>
     </dl>
 
-    <h4>User Interaction</h4>
+    <h4 id="ui">User Interaction</h4>
 
     <p>
       This section lists function related to window and message line manipulation, keyboard input and system
       interaction.
     </p>
 
-    <h5>Window Handling</h5>
+    <h5 id="windows">Window Handling</h5>
 
     <dl>
       <dt><code>(delete-other-windows)</code></dt>
@@ -579,7 +626,7 @@
       <dd>Updates all windows by marking them modified and calling <code>update-display</code>.</dd>
     </dl>
 
-    <h5>Message Line</h5>
+    <h5 id="message_line">Message Line</h5>
     <dl>
       <dt><code>(message <var>string</var>)</code></dt>
       <dd>Displays <var>string</var> in the message line. <u>D</u></dd>
@@ -588,21 +635,21 @@
       <dt><code>(prompt <var>prompt</var> <var>default</var>)</code></dt>
       <dd>
 	Displays <var>prompt</var> in the command line and sets <var>default</var> as initial value for the user
-	respones. The user can edit the response. When hitting return, the final response is returned.
+	response. The user can edit the response. When hitting return, the final response is returned.
       </dd>
       <dt><code>(show-prompt <var>prompt</var> <var>default</var>)</code></dt>
       <dd>
-	Displays <var>prompt</var> and <var>default</var> in the commandline, but does not allow
+	Displays <var>prompt</var> and <var>default</var> in the command line, but does not allow
 	editing. Returns <code>t</code>.
       </dd>
       <dt><code>(prompt-filename <var>prompt</var>)</code></dt>
       <dd>
-	Displays <var>prompt</var> in the commandline and allows to enter or search for a file name. Returns the
+	Displays <var>prompt</var> in the command line and allows to enter or search for a file name. Returns the
 	relative path to the selected file name or the response typed by the user.
       </dd>
     </dl>
 
-    <h5>Keyboard Handling</h5>
+    <h5 id="keyboard">Keyboard Handling</h5>
 
     <dl>
       <dt><code>(set-key <var>key-name</var> <var>lisp-func</var>)</code></dt>
@@ -630,7 +677,7 @@
       </dd>
     </dl>
 
-    <h5>Programming and System Interaction</h5>
+    <h5 id="programming_system">Programming and System Interaction</h5>
 
     <dl>
       <dt><code>(exit)</code></dt>
@@ -657,9 +704,142 @@
       <dd>Returns the complete version string of Femto, including the copyright.</dd>
     </dl>
     
-    <h3>Implementation Details</h3>
 
-    <p><mark>Tbd.: Memory consumption, limits, hacking, ...</mark></p>
+    <h3 id="exceptions">Error handling</h3>
+    <p>
+      Whenever fLisp encounters an error an exception is thrown. Exceptions have a non-zero result code and an error
+      message.  The error message is a string containing the serialization of the object causing the error — if any —
+      and an individual user readable string.
+    </p>
+    <p>
+      fLisp does not implement stack backtracking. exceptions are only caught on the top level of an evaluation.
+    </p>
+    <p>Exceptions can be thrown in Lisp code via the <a href="#interp_ops"><code>signal</code></a> function.</p>
+    <p>
+      <mark>Note: currently the error result code is always 1. It is planned to distinguish different error classes,
+	e.g. parsing errors, execution errors, I/O errors, input errors, …
+      </mark>
+    </p>
+    <h3 id="embedding">Embedding fLisp</h3>
+    <p>
+      fLisp exposes the following public interfaces:
+    </p>
+    <dl>
+      <dt><code><var>Interpreter</var> *lisp_init(int <var>argc</var>, char **<var>argv</var>, char
+	  *<var>library_path</var>)</code></dt>
+      <dd>
+	<p><code>lisp_init()</code> creates and initializes an fLisp interpreter.  The initial environment contains the
+	  following symbols:
+	</p>
+	<dl>
+	  <dt><var>argv0</var></dt><dd>The string stored in <code>*<var>argv</var>[0]</code>, if any</dd>
+	  <dt><var>argv</var></dt><dd>The list of strings stored in <code><var>argv</var></code></dd>
+	  <dt><var>script_dir</var></dt><dd>The string stored in <code><var>library_path</var></code></dd>
+	</dl>
+	<p>A pointer to an <var>Interpreter</var> struct is returned, which is used to operate the interpreter.</p>
+      </dd>
+      <dt><code><var>ResultCode</var> lisp_eval(<var>interp</var>, <var>format</var>, …)</code></dt>
+      <dd>
+	<p>
+	  Evaluates input in the fLisp interpreter <var>interp</var>.  The input is generated the same way as
+	  in <code>printf()</code> from the <var>format</var> string and any following optional arguments.
+	</p>
+	<p>
+	  The <var>ResultCode</var> is <code>0</code> when the input is evaluated successfully and non-zero if any error
+	  occurred during evaluation.  The result code is also stored in <var>interp-&gt;result</var>.
+	</p>
+	<p>
+	  After evaluation <var>interp-&gt;output</var> contains the output of the evaluation
+	  and <var>interp-&gt;message</var> contains the error message if result code is non-zero.
+      </dd>
+    </dl>
+    <p><mark>Note: currently only one interpreter can be created.</mark></p>
+    
+    <h3 id="implementation">Implementation Details</h3>
+
+    <h4 id="gc">Garbage Collection</h4>
+    <p>
+      fLisp implements Cheney&apos;s copying garbage collector, with which memory is divided into two equal halves
+      (semi spaces): from- and to-space. From-space is where new objects are allocated, whereas to-space is used during
+      garbage collection.
+    </p>
+    <p>
+      When garbage collection is performed, objects that are still in use (live) are copied from from-space to
+      to-space. To-space then becomes the new from-space and vice versa, thereby discarding all objects that have not
+      been copied.
+    </p>
+    <p>
+      Our garbage collector takes as input a list of root objects. Objects that can be reached by recursively traversing
+      this list are considered live and will be moved to to-space. When we move an object, we must also update its
+      pointer within the list to point to the objects new location in memory.
+    </p>
+    <p>
+      However, this implies that our interpreter cannot use raw pointers to objects in any function that might trigger
+      garbage collection (or risk causing a SEGV when accessing an object that has been moved). Instead, objects must be
+      added to the list and then only accessed through the pointer inside the list.
+    </p>
+    <p>
+      Thus, whenever we would have used a raw pointer to an object, we use a pointer to the pointer inside the list
+      instead:
+    </p>
+    <pre>
+function:              pointer to pointer inside list (Object **)
+                               |
+                               v
+list of root objects:  pointer to object (Object *)
+                               |
+                               v
+semi space:             object in memory
+    </pre>
+    <p>
+      <code><var>GC_ROOTS</var></code> and <code><var>GC_PARAM</var></code> are used to pass the list from function to
+      function.
+    </p>
+    <p>
+      <code><var>GC_TRACE</var></code> adds an object to the list and declares a variable which points to the objects
+      pointer inside the list.
+    </p>
+    <p>
+      <code><var>GC_TRACE</var>(<var>gcX</var>, <var>X</var>)</code>: add object <var>X</var> to the list and
+      declare <code>Object **<var>gcX</var></code> to point to the pointer to <var>X</var> inside the list.
+    </p>
+    <h4 id="memory">Memory Usage</h4>
+    <p>
+      Some compile time adjustable limits in <code>lisp.h</code>:
+    </p>
+    <dl>
+      <dt>Object memory</dt><dd>4M, <code>FLISP_MEMORY_SIZE</code>.</dd>
+      <dt>Input buffer</dt><dd>2048, <code>INPUT_FMT_BUFSIZ</code>, size of the formatting buffer for <code>lisp_eval()</code>.</dd>
+      <dt>Output buffer</dt><dd>2048, <code>WRITE_FMT_BUFSIZ</code>, size of the output and message formatting buffer.</dd>
+    </dl>
+    <p>
+      fLisp can live with much less object memory, but the <q>OXO</q> game requires a lot and <mark>the garbage
+	collector has a bug</mark> which makes OXO segfault.
+    </p>
+
+    <h4 id="future">Future Directions</h4>
+    <p>
+      fLisp could be made completely independent of Femto, thus making the interpreter embeddable in any
+      application. The <code>debug()</code> function is still borrowed from <code>main.c</code> and it has to be devised
+      how to extend the interpreter dynamically; the editor extensions are currently compiled into the interpreter.
+    </p>
+    <p>
+      Integer arithmetic would be sufficient for all current purposes and increase portability, speed while reducing
+      size.
+    </p>
+    <p>
+      The internally used <q>Stream</q> abstraction for reading Lisp input and writing output is incomplete and
+      complicated. An alternative would be to use only string input and output. File input can be read as a whole into
+      memory and use the string input processing.  This would also have consequences for the Lisp reader and probably
+      simplify implementation of improved error reporting, a lá line/char offset reporting.  The downside is, that this
+      would remove support for <code>stdin</code>/<code>stdout</code> reading/writing.
+    </p>
+    <p>
+      Exception handling should be improved by returning differentiated error codes. One of the benefits would be the
+      possibility to implement externally an interactive repl with <code>stdin</code>/<code>stdout</code> streams, by
+      reading and eval&apos;ing until no more <q>incomplete input</q> result codes are returned.
+    </p>
+    
   </body>
 </html>
 <!--

--- a/pdoc/h2m.lua
+++ b/pdoc/h2m.lua
@@ -1,0 +1,36 @@
+--local logging = require 'logging'
+local function index(list,needle)
+   for i,element in ipairs(list) do
+      if element == needle then return i end
+   end
+end
+return {
+   {
+      Inlines = function(list)
+	 local l = pandoc.List {}
+	 for i,elem in ipairs(list) do
+	    if elem.tag == 'Code' then
+	       local last = l[#l]
+	       if last and last.tag == 'Code' and not index(last.attr.classes, 'variable')  then
+		  l:remove()
+		  local text = elem.text
+		  if index(elem.attr.classes, 'variable') then
+		     text = '«'..text..'»'
+		  end
+		  combined = pandoc.Code(last.text..text, last.attr)
+		  l:insert(combined)
+	       else
+		  if index(elem.attr.classes, 'variable') then
+		     l:insert(pandoc.Emph(elem.text))
+		  else
+		     l:insert(elem)
+		  end
+	       end
+	    else
+	       l:insert(elem)
+	    end
+	 end
+	 return l
+      end
+   }
+}


### PR DESCRIPTION
Add rmkx mode esc sequence for home and end key
    
Note: in order to make home and end keys to work in rmkx mode
(xfce4-terminal default?)  they had to be defined *first* in the
keybindings, otherwise one of the two keys would not work. Now
one of them does not work in skmx mode.  An obvious reason for
this behavior was not apparent.
