### PR TITLE
femto 2.22 added toggle_text_mode

### DIFF
--- a/CHANGE.LOG.md
+++ b/CHANGE.LOG.md
@@ -1,3 +1,10 @@
+## Femto 2.22/fLisp 0.5 Aug 2025
+
+Added toggle-text-mode as start of being able to have different syntax high light
+behaviour in different buffers
+
+Fixed reporting of 'Line 0, not found' when files are loaded
+
 ## Femto 2.21/fLisp 0.5 May 2025
 
 Fix remaining gc issues with macros and re-instate and macro.

--- a/command.c
+++ b/command.c
@@ -288,7 +288,8 @@ int goto_line(int line)
         msg(m_line, line);
         return 1;
     } else {
-        msg(m_lnot_found, line);
+        if (line > 0)
+            msg(m_lnot_found, line);
         return 0;
     }
 }
@@ -400,6 +401,16 @@ void toggle_overwrite_mode() {
         curbp->b_flags &= ~B_OVERWRITE;
     else
         curbp->b_flags |= B_OVERWRITE;
+}
+
+/* suppress single quote matching for text files where we want to ignore apostraphe etc */
+void toggle_text_mode() {
+    if (curbp->b_flags & B_TEXT)
+        curbp->b_flags &= ~B_TEXT;
+    else
+        curbp->b_flags |= B_TEXT;
+
+    redraw(); /* mark the lot for update */
 }
 
 int i_check_region()

--- a/docs/hltest.c
+++ b/docs/hltest.c
@@ -79,3 +79,10 @@ s="£";
 s=":";
 
 /* */
+
+'This text will appear as a string (GOLD) as the single quote is not completed
+except in TEXT mode where it will appear as normal text
+do esc-x toggle-text-mode and see how this text gets rendered
+when text mode is on the text will appear in CYAN
+
+

--- a/femto.primitives.c
+++ b/femto.primitives.c
@@ -43,6 +43,7 @@ DEFINE_EDITOR_FUNC(describe_functions)
 DEFINE_EDITOR_FUNC(split_window)
 DEFINE_EDITOR_FUNC(other_window)
 DEFINE_EDITOR_FUNC(execute_key)
+DEFINE_EDITOR_FUNC(toggle_text_mode)
 
 extern int set_key(char *, char *);
 extern int getinput(char *, char *, int, int);

--- a/femto.register.c
+++ b/femto.register.c
@@ -1,4 +1,13 @@
+/*
+This file is included in lisp.c
+
+Here we register editor commands that we want to be
+available to be called as lisp functions
+
+*/
+
     {"get-temp-file", 0, 0, e_get_temp_file},
+    {"toggle-text-mode", 0, 0, e_toggle_text_mode},
     {"add-mode-global", 1, 1, e_add_mode_global},
     {"message", 1, 1, e_message},
     {"log-message", 1, 1, e_log_message},

--- a/header.h
+++ b/header.h
@@ -18,7 +18,7 @@
 int mkstemp(char *);
 
 #define E_NAME          "femto"
-#define E_VERSION       "2.21"
+#define E_VERSION       "2.22"
 #define E_LABEL         "Femto:"
 #define E_NOT_BOUND     "<not bound>"
 #ifndef E_SCRIPTDIR
@@ -27,7 +27,7 @@ int mkstemp(char *);
 #ifndef E_INITFILE
 #define E_INITFILE      "/usr/local/share/femto/femto.rc"
 #endif
-#define E_VERSION_STR    E_NAME " " E_VERSION ", Public Domain, July 2025, by Hugh Barney, Georg Lehner, No warranty."
+#define E_VERSION_STR    E_NAME " " E_VERSION ", Public Domain, August 2025, by Hugh Barney, Georg Lehner, No warranty."
 
 #define MSGLINE         (LINES-1)
 #define NOMARK          -1
@@ -91,6 +91,7 @@ typedef enum {
     B_OVERWRITE = 0x02,         /* overwite mode */
     B_SPECIAL = 0x04,           /* is a special buffer name of form '*name*' */
     B_UNDO = 0x08,              /* undo mode */
+    B_TEXT = 0x10,              /* text mode, suppress single quote handling */
 } buffer_flags_t;
 
 typedef struct string_list_t
@@ -351,6 +352,7 @@ extern void unmark();
 extern void up();
 extern void user_func();
 extern void version();
+extern void toggle_text_mode();
 extern void writefile();
 extern void yank();
 

--- a/hilite.c
+++ b/hilite.c
@@ -79,7 +79,8 @@ int parse_text(buffer_t *bp, point_t pt)
         return ID_DOUBLE_STRING;
     }
 
-    if (state == ID_DEFAULT && c_now == '\'')
+    // suppress single quote matching if in text mode
+    if ( !(bp->b_flags & B_TEXT)  && state == ID_DEFAULT && c_now == '\'')
         return (next_state = ID_SINGLE_STRING);
 
     if (state == ID_SINGLE_STRING && c_now == '\\') {

--- a/key.c
+++ b/key.c
@@ -161,6 +161,7 @@ void setup_keys()
     set_key_internal("esc-m",   "set-mark"              , "\x1B\x6D", i_set_mark);
     set_key_internal("esc-n",   "next-buffer"           , "\x1B\x6E", next_buffer);
     set_key_internal("esc-o",   "delete-other-windows"  , "\x1B\x6F", delete_other_windows);
+    set_key_internal("esc-q",   "kill-buffer"           , "\x1B\x71", kill_buffer);
     set_key_internal("esc-r",   "query-replace"         , "\x1B\x72", query_replace);
     set_key_internal("esc-v",   "page-up"               , "\x1B\x76", backward_page);
     set_key_internal("esc-w",   "copy-region"           , "\x1B\x77", copy_region);
@@ -224,9 +225,10 @@ void setup_keys()
 
     set_key_internal("c-c f",     "describe-functions"    , "\x03\x66", describe_functions);
 
+    // command will be registered so that it will get searched for when prompted as execute-command (esc-x)
     register_command("show-version", version);
+    register_command("toggle-text-mode", toggle_text_mode);
 }
-
 
 char_t *get_key(keymap_t *keys, keymap_t **key_return)
 {

--- a/makefile
+++ b/makefile
@@ -76,7 +76,7 @@ femto: $(OBJ) femto.rc
 
 femto.rc: femto.sht lisp/core.lsp
 
-femto_lisp.o: lisp.c
+femto_lisp.o: lisp.c femto.register.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -D FLISP_FEMTO_EXTENSION -c lisp.c -o $@
 
 flisp: $(FLISP_OBJ) flisp.rc


### PR DESCRIPTION
see CHANGE.log.md

Added toggle-text-mode command to suppress single quote matching on the current buffer.

Fixed goto_line so that we dont report and error on line 0

